### PR TITLE
Add handler404, dark mode toggle, and 17 new tests

### DIFF
--- a/blog/forms.py
+++ b/blog/forms.py
@@ -33,16 +33,7 @@ class UpdateBlogPostForm(forms.ModelForm):
 		}
 
 	def save(self, commit=True):
-		blog_post = self.instance
-		blog_post.title = self.cleaned_data['title']
-		blog_post.body = self.cleaned_data['body']
-		blog_post.category = self.cleaned_data['category']
-		blog_post.status = self.cleaned_data['status']
-
-		if self.cleaned_data['image']:
-			blog_post.image = self.cleaned_data['image']
-
-		if commit:
-			blog_post.save()
-			self.save_m2m()
-		return blog_post
+		# Keep existing image if no new one uploaded
+		if not self.cleaned_data.get('image'):
+			self.cleaned_data['image'] = self.instance.image
+		return super().save(commit=commit)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -249,3 +249,135 @@ class AuthorProfileTests(ModelTestMixin, TestCase):
 	def test_author_profile_404_for_nonexistent(self):
 		response = self.client.get(reverse('author_profile', args=['nobody']))
 		self.assertEqual(response.status_code, 404)
+
+
+class CreatePostViewTests(ModelTestMixin, TestCase):
+
+	def test_create_requires_auth(self):
+		response = self.client.get(reverse('blog:create'))
+		self.assertEqual(response.status_code, 302)
+
+	def test_create_page_loads_for_authenticated(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.get(reverse('blog:create'))
+		self.assertEqual(response.status_code, 200)
+
+	def test_create_post_submission(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.post(reverse('blog:create'), {
+			'title': 'New Blog Post',
+			'body': 'This is the body of a new blog post with enough content.',
+			'status': 'published',
+			'category': self.category.pk,
+		})
+		self.assertEqual(response.status_code, 302)
+		self.assertTrue(BlogPost.objects.filter(title='New Blog Post').exists())
+
+
+class EditPostViewTests(ModelTestMixin, TestCase):
+
+	def test_edit_requires_auth(self):
+		response = self.client.get(reverse('blog:edit', args=[self.post.slug]))
+		self.assertEqual(response.status_code, 302)
+
+	def test_edit_denied_for_non_author(self):
+		self.client.login(email='other@nyasablog.com', password='testpass123')
+		response = self.client.get(reverse('blog:edit', args=[self.post.slug]))
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, 'You are not the author')
+
+	def test_edit_page_loads_for_author(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.get(reverse('blog:edit', args=[self.post.slug]))
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, 'Edit Story')
+
+	def test_edit_post_submission(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.post(reverse('blog:edit', args=[self.post.slug]), {
+			'title': 'Updated Title',
+			'body': 'Updated body content here.',
+			'status': 'published',
+		})
+		self.assertEqual(response.status_code, 200)
+		self.post.refresh_from_db()
+		self.assertEqual(self.post.title, 'Updated Title')
+
+
+class DeletePostViewTests(ModelTestMixin, TestCase):
+
+	def test_delete_requires_auth(self):
+		response = self.client.get(reverse('blog:delete', args=[self.post.pk]))
+		self.assertEqual(response.status_code, 302)
+
+	def test_delete_denied_for_non_author(self):
+		self.client.login(email='other@nyasablog.com', password='testpass123')
+		response = self.client.get(reverse('blog:delete', args=[self.post.pk]))
+		self.assertContains(response, 'You are not the author')
+
+	def test_delete_confirmation_page_loads(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.get(reverse('blog:delete', args=[self.post.pk]))
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, 'delete')
+
+	def test_delete_post_submission(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		post_pk = self.post.pk
+		response = self.client.post(reverse('blog:delete', args=[post_pk]))
+		self.assertEqual(response.status_code, 302)
+		self.assertFalse(BlogPost.objects.filter(pk=post_pk).exists())
+
+
+class CommentSubmissionTests(ModelTestMixin, TestCase):
+
+	def test_comment_requires_auth(self):
+		response = self.client.post(
+			reverse('blog:detail', args=[self.post.slug]),
+			{'body': 'Anonymous comment'}
+		)
+		# Unauthenticated POST redirects or ignores comment
+		self.assertEqual(Comment.objects.count(), 0)
+
+	def test_comment_submission(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.post(
+			reverse('blog:detail', args=[self.post.slug]),
+			{'body': 'Great article!'}
+		)
+		self.assertEqual(response.status_code, 302)
+		self.assertEqual(Comment.objects.count(), 1)
+		self.assertEqual(Comment.objects.first().body, 'Great article!')
+
+	def test_reply_submission(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		parent = Comment.objects.create(post=self.post, author=self.user, body='Parent comment')
+		response = self.client.post(
+			reverse('blog:detail', args=[self.post.slug]),
+			{'body': 'Reply to parent', 'parent_id': parent.pk}
+		)
+		self.assertEqual(response.status_code, 302)
+		reply = Comment.objects.filter(parent=parent).first()
+		self.assertIsNotNone(reply)
+		self.assertEqual(reply.body, 'Reply to parent')
+
+	def test_delete_comment_by_author(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		comment = Comment.objects.create(post=self.post, author=self.user, body='To delete')
+		response = self.client.post(reverse('blog:delete_comment', args=[comment.pk]))
+		self.assertEqual(response.status_code, 302)
+		self.assertFalse(Comment.objects.filter(pk=comment.pk).exists())
+
+	def test_delete_comment_denied_for_non_author(self):
+		self.client.login(email='other@nyasablog.com', password='testpass123')
+		comment = Comment.objects.create(post=self.post, author=self.user, body='Not yours')
+		response = self.client.get(reverse('blog:delete_comment', args=[comment.pk]))
+		self.assertContains(response, 'You are not the author')
+
+
+class BookmarkTogglePostMethodTests(ModelTestMixin, TestCase):
+
+	def test_bookmark_requires_post_method(self):
+		self.client.login(email='test@nyasablog.com', password='testpass123')
+		response = self.client.get(reverse('blog:bookmark', args=[self.post.slug]))
+		self.assertEqual(response.status_code, 405)

--- a/blog/views.py
+++ b/blog/views.py
@@ -90,11 +90,8 @@ def edit_blog_view(request, slug):
 	if request.POST:
 		form = UpdateBlogPostForm(request.POST or None, request.FILES or None, instance=blog_post)
 		if form.is_valid():
-			obj = form.save(commit=False)
-			obj.save()
-			form.save_m2m()
+			blog_post = form.save()
 			context['success_message'] = "Updated"
-			blog_post = obj
 	else:
 		form = UpdateBlogPostForm(
 			initial={

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -73,7 +73,8 @@ urlpatterns = [
      name='password_reset_complete'),
 ]
 
+handler404 = 'django.views.defaults.page_not_found'
+
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-   

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html class="light" lang="en">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -81,9 +81,18 @@ tailwind.config = {
 }
 </script>
 {% include 'snippets/base_css.html' %}
+<script>
+// Apply theme before render to prevent flash
+(function() {
+  var theme = localStorage.getItem('theme');
+  if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.classList.add('dark');
+  }
+})();
+</script>
 {% block extra_head %}{% endblock %}
 </head>
-<body class="bg-background text-on-surface font-body selection:bg-secondary-container selection:text-on-secondary-container">
+<body class="bg-background dark:bg-slate-950 text-on-surface dark:text-slate-200 font-body selection:bg-secondary-container selection:text-on-secondary-container transition-colors duration-300">
 
 {% include 'snippets/header.html' %}
 
@@ -95,5 +104,25 @@ tailwind.config = {
 {% include 'snippets/footer.html' %}
 
 {% block extra_js %}{% endblock %}
+<script>
+function toggleTheme() {
+  var html = document.documentElement;
+  var icon = document.getElementById('theme-icon');
+  if (html.classList.contains('dark')) {
+    html.classList.remove('dark');
+    localStorage.setItem('theme', 'light');
+    if (icon) icon.textContent = 'dark_mode';
+  } else {
+    html.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+    if (icon) icon.textContent = 'light_mode';
+  }
+}
+// Set correct icon on load
+document.addEventListener('DOMContentLoaded', function() {
+  var icon = document.getElementById('theme-icon');
+  if (icon) icon.textContent = document.documentElement.classList.contains('dark') ? 'light_mode' : 'dark_mode';
+});
+</script>
 </body>
 </html>

--- a/templates/snippets/header.html
+++ b/templates/snippets/header.html
@@ -33,6 +33,11 @@
       <span class="material-symbols-outlined text-on-surface">search</span>
     </a>
 
+    <!-- Dark mode toggle -->
+    <button onclick="toggleTheme()" class="p-2 text-on-surface-variant hover:text-primary transition-colors" title="Toggle dark mode">
+      <span class="material-symbols-outlined" id="theme-icon">dark_mode</span>
+    </button>
+
     {% if request.user.is_authenticated %}
       <!-- Bookmarks -->
       <a href="{% url 'blog:bookmarks' %}" class="hidden md:block p-2" title="Bookmarks">


### PR DESCRIPTION
## Summary
- **handler404** set in urls.py — 404.html template now renders in production
- **Dark mode toggle** — sun/moon button in header, persists to localStorage, respects prefers-color-scheme, flash-prevention script
- **17 new tests** (55 total) — create/edit/delete post views, comment submission/reply/delete, bookmark POST enforcement
- **Bug fix** — UpdateBlogPostForm.save() was calling self.save_m2m() without super(), causing AttributeError

## Test plan
- [x] `python manage.py test blog` — 55 tests pass
- [x] `python manage.py check` — no issues
- [x] Dark mode toggle persists across page loads
- [x] Edit post form saves correctly