### PR TITLE
Add missing REST API endpoints for all Phase 1 features

### DIFF
--- a/account/api/serializers.py
+++ b/account/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from account.models import Account
+from account.models import Account, UserProfile
 
 
 # class LoginSerializer(serializers.ModelSerializer):
@@ -51,6 +51,16 @@ class ChangePasswordSerializer(serializers.Serializer):
 
 	old_password 				= serializers.CharField(required=True)
 	new_password 				= serializers.CharField(required=True)
-	confirm_new_password 		= serializers.CharField(required=True)		
+	confirm_new_password 		= serializers.CharField(required=True)
 
 
+class UserProfileSerializer(serializers.ModelSerializer):
+	username = serializers.CharField(source='user.username', read_only=True)
+	email = serializers.CharField(source='user.email', read_only=True)
+	date_joined = serializers.DateTimeField(source='user.date_joined', read_only=True)
+
+	class Meta:
+		model = UserProfile
+		fields = ['username', 'email', 'date_joined', 'bio', 'avatar', 'location',
+				  'website', 'twitter', 'facebook', 'instagram', 'linkedin']
+		read_only_fields = ['username', 'email', 'date_joined']

--- a/account/api/urls.py
+++ b/account/api/urls.py
@@ -6,6 +6,8 @@ from account.api.views import(
 	update_account_view,
 	does_account_exist_view,
 	ChangePasswordView,
+	api_author_profile_view,
+	api_update_profile_view,
 )
 from rest_framework.authtoken.views import obtain_auth_token
 
@@ -16,7 +18,8 @@ urlpatterns = [
 	path('change_password/', ChangePasswordView.as_view(), name="change_password"),
 	path('properties', account_properties_view, name="properties"),
 	path('properties/update', update_account_view, name="update"),
- 	path('login', ObtainAuthTokenView.as_view(), name="login"), 
+ 	path('login', ObtainAuthTokenView.as_view(), name="login"),
 	path('register', registration_view, name="register"),
-
+	path('profile/<str:username>/', api_author_profile_view, name="author_profile"),
+	path('profile/update/', api_update_profile_view, name="update_profile"),
 ]

--- a/account/api/views.py
+++ b/account/api/views.py
@@ -8,9 +8,10 @@ from django.contrib.auth import authenticate
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 
-from account.api.serializers import RegistrationSerializer,AccountPropertiesSerializer,ChangePasswordSerializer
-from account.models import Account
+from account.api.serializers import RegistrationSerializer, AccountPropertiesSerializer, ChangePasswordSerializer, UserProfileSerializer
+from account.models import Account, UserProfile
 from rest_framework.authtoken.models import Token
+from django.db.models import Sum, Count
 
 
 # Register
@@ -179,3 +180,34 @@ class ChangePasswordView(UpdateAPIView):
 
 		return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
+@api_view(['GET'])
+@permission_classes([])
+def api_author_profile_view(request, username):
+	try:
+		account = Account.objects.select_related('profile').get(username=username)
+	except Account.DoesNotExist:
+		return Response(status=status.HTTP_404_NOT_FOUND)
+
+	from blog.models import BlogPost
+	posts = BlogPost.objects.filter(author=account, status='published')
+	stats = posts.aggregate(
+		total_views=Sum('view_count'),
+		post_count=Count('id'),
+	)
+
+	profile_data = UserProfileSerializer(account.profile).data
+	profile_data['post_count'] = stats['post_count']
+	profile_data['total_views'] = stats['total_views'] or 0
+	return Response(profile_data)
+
+
+@api_view(['PUT'])
+@permission_classes((IsAuthenticated,))
+def api_update_profile_view(request):
+	profile = request.user.profile
+	serializer = UserProfileSerializer(profile, data=request.data, partial=True)
+	if serializer.is_valid():
+		serializer.save()
+		return Response(serializer.data)
+	return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/blog/api/serializers.py
+++ b/blog/api/serializers.py
@@ -42,6 +42,17 @@ class CommentSerializer(serializers.ModelSerializer):
 		return []
 
 
+class CommentCreateSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Comment
+		fields = ['body', 'parent']
+
+	def validate_parent(self, value):
+		if value and value.parent is not None:
+			raise serializers.ValidationError("Replies can only be one level deep.")
+		return value
+
+
 class BlogPostSerializer(serializers.ModelSerializer):
 
 	username = serializers.SerializerMethodField('get_username_from_author')

--- a/blog/api/urls.py
+++ b/blog/api/urls.py
@@ -5,16 +5,41 @@ from blog.api.views import(
 	api_delete_blog_view,
 	api_create_blog_view,
 	api_is_author_of_blogpost,
-	ApiBlogListView
+	ApiBlogListView,
+	api_categories_view,
+	api_tags_view,
+	api_comments_view,
+	api_create_comment_view,
+	api_delete_comment_view,
+	api_toggle_like_view,
+	api_toggle_bookmark_view,
+	api_bookmarks_view,
 )
 
 app_name = 'blog'
 
 urlpatterns = [
+	# Blog CRUD
 	path('create', api_create_blog_view, name="create"),
 	path('list', ApiBlogListView.as_view(), name="list"),
+
+	# Categories & Tags
+	path('categories/', api_categories_view, name="categories"),
+	path('tags/', api_tags_view, name="tags"),
+
+	# Bookmarks (user's list)
+	path('bookmarks/', api_bookmarks_view, name="bookmarks"),
+
+	# Comments
+	path('comments/<int:pk>/delete/', api_delete_comment_view, name="delete_comment"),
+
+	# Post-specific endpoints (slug-based must come after static paths)
 	path('<slug>/', api_detail_blog_view, name="detail"),
 	path('<slug>/update', api_update_blog_view, name="update"),
 	path('<slug>/delete', api_delete_blog_view, name="delete"),
 	path('<slug>/is_author', api_is_author_of_blogpost, name="is_author"),
+	path('<slug>/comments/', api_comments_view, name="comments"),
+	path('<slug>/comments/create/', api_create_comment_view, name="create_comment"),
+	path('<slug>/like/', api_toggle_like_view, name="like"),
+	path('<slug>/bookmark/', api_toggle_bookmark_view, name="bookmark"),
 ]

--- a/blog/api/views.py
+++ b/blog/api/views.py
@@ -9,8 +9,11 @@ from rest_framework.filters import SearchFilter, OrderingFilter
 
 
 from account.models import Account
-from blog.models import BlogPost
-from blog.api.serializers import BlogPostSerializer, BlogPostUpdateSerializer,BlogPostCreateSerializer
+from blog.models import BlogPost, Category, Tag, Comment, Like, Bookmark
+from blog.api.serializers import (
+	BlogPostSerializer, BlogPostUpdateSerializer, BlogPostCreateSerializer,
+	CategorySerializer, TagSerializer, CommentSerializer, CommentCreateSerializer,
+)
 
 SUCCESS = 'success'
 ERROR = 'error'
@@ -145,10 +148,121 @@ def api_create_blog_view(request):
 #		4) search + pagination + ordering: <your-domain>/api/blog/list?search=mitch&page=2&ordering=-date_updated
 # Headers: Authorization: Token <token>
 class ApiBlogListView(ListAPIView):
-	queryset = BlogPost.objects.all()
 	serializer_class = BlogPostSerializer
 	authentication_classes = (TokenAuthentication,)
 	permission_classes = (IsAuthenticated,)
 	pagination_class = PageNumberPagination
 	filter_backends = (SearchFilter, OrderingFilter)
 	search_fields = ('title', 'body', 'author__username')
+	ordering_fields = ('date_updated', 'view_count', 'title')
+
+	def get_queryset(self):
+		queryset = BlogPost.objects.all()
+		category = self.request.query_params.get('category')
+		status_filter = self.request.query_params.get('status')
+		if category:
+			queryset = queryset.filter(category__slug=category)
+		if status_filter:
+			queryset = queryset.filter(status=status_filter)
+		return queryset
+
+
+# --- Categories & Tags ---
+
+@api_view(['GET'])
+@permission_classes([])
+def api_categories_view(request):
+	categories = Category.objects.all()
+	serializer = CategorySerializer(categories, many=True)
+	return Response(serializer.data)
+
+
+@api_view(['GET'])
+@permission_classes([])
+def api_tags_view(request):
+	tags = Tag.objects.all()
+	serializer = TagSerializer(tags, many=True)
+	return Response(serializer.data)
+
+
+# --- Comments ---
+
+@api_view(['GET'])
+@permission_classes([])
+def api_comments_view(request, slug):
+	try:
+		post = BlogPost.objects.get(slug=slug)
+	except BlogPost.DoesNotExist:
+		return Response(status=status.HTTP_404_NOT_FOUND)
+	comments = post.comments.filter(parent=None, is_active=True).select_related('author').prefetch_related('replies__author')
+	serializer = CommentSerializer(comments, many=True)
+	return Response(serializer.data)
+
+
+@api_view(['POST'])
+@permission_classes((IsAuthenticated,))
+def api_create_comment_view(request, slug):
+	try:
+		post = BlogPost.objects.get(slug=slug)
+	except BlogPost.DoesNotExist:
+		return Response(status=status.HTTP_404_NOT_FOUND)
+
+	serializer = CommentCreateSerializer(data=request.data)
+	if serializer.is_valid():
+		serializer.save(post=post, author=request.user)
+		return Response(serializer.data, status=status.HTTP_201_CREATED)
+	return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['DELETE'])
+@permission_classes((IsAuthenticated,))
+def api_delete_comment_view(request, pk):
+	try:
+		comment = Comment.objects.get(pk=pk)
+	except Comment.DoesNotExist:
+		return Response(status=status.HTTP_404_NOT_FOUND)
+
+	if comment.author != request.user:
+		return Response({'response': "You don't have permission to delete this comment."}, status=status.HTTP_403_FORBIDDEN)
+	comment.delete()
+	return Response({'response': 'deleted'})
+
+
+# --- Likes & Bookmarks ---
+
+@api_view(['POST'])
+@permission_classes((IsAuthenticated,))
+def api_toggle_like_view(request, slug):
+	try:
+		post = BlogPost.objects.get(slug=slug)
+	except BlogPost.DoesNotExist:
+		return Response(status=status.HTTP_404_NOT_FOUND)
+
+	like, created = Like.objects.get_or_create(post=post, user=request.user)
+	if not created:
+		like.delete()
+		return Response({'liked': False, 'count': post.likes.count()})
+	return Response({'liked': True, 'count': post.likes.count()})
+
+
+@api_view(['POST'])
+@permission_classes((IsAuthenticated,))
+def api_toggle_bookmark_view(request, slug):
+	try:
+		post = BlogPost.objects.get(slug=slug)
+	except BlogPost.DoesNotExist:
+		return Response(status=status.HTTP_404_NOT_FOUND)
+
+	bookmark, created = Bookmark.objects.get_or_create(post=post, user=request.user)
+	if not created:
+		bookmark.delete()
+		return Response({'bookmarked': False})
+	return Response({'bookmarked': True})
+
+
+@api_view(['GET'])
+@permission_classes((IsAuthenticated,))
+def api_bookmarks_view(request):
+	bookmarked_posts = BlogPost.objects.filter(bookmarks__user=request.user).order_by('-bookmarks__created_at')
+	serializer = BlogPostSerializer(bookmarked_posts, many=True)
+	return Response(serializer.data)

--- a/personal/templates/personal/api.html
+++ b/personal/templates/personal/api.html
@@ -178,7 +178,9 @@
           <h4 class="text-xs font-bold uppercase tracking-widest text-secondary mb-4">Query Parameters</h4>
           <ul class="space-y-3 text-sm">
             <li class="flex justify-between border-b border-outline-variant/20 pb-2"><span class="font-mono font-semibold">search</span> <span class="text-on-surface-variant italic">String</span></li>
-            <li class="flex justify-between border-b border-outline-variant/20 pb-2"><span class="font-mono font-semibold">ordering</span> <span class="text-on-surface-variant italic">title, body, date_updated</span></li>
+            <li class="flex justify-between border-b border-outline-variant/20 pb-2"><span class="font-mono font-semibold">category</span> <span class="text-on-surface-variant italic">Slug (e.g. culture)</span></li>
+            <li class="flex justify-between border-b border-outline-variant/20 pb-2"><span class="font-mono font-semibold">status</span> <span class="text-on-surface-variant italic">published / draft</span></li>
+            <li class="flex justify-between border-b border-outline-variant/20 pb-2"><span class="font-mono font-semibold">ordering</span> <span class="text-on-surface-variant italic">title, date_updated, view_count</span></li>
             <li class="flex justify-between border-b border-outline-variant/20 pb-2"><span class="font-mono font-semibold">page</span> <span class="text-on-surface-variant italic">Int (10 per page)</span></li>
           </ul>
         </div>
@@ -192,6 +194,110 @@
     {"title": "...", "slug": "...", ...}
   ]
 }</pre>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 7: Categories -->
+    <section id="categories" class="mb-16 scroll-mt-28 border-t border-outline-variant/10 pt-12">
+      <div class="flex items-center gap-3 mb-6">
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-secondary text-on-secondary uppercase tracking-wider">GET</span>
+        <h2 class="text-2xl font-bold text-primary">List Categories</h2>
+      </div>
+      <p class="text-sm text-on-surface-variant mb-4">Public — no authentication required.</p>
+      <div class="bg-surface-container-low rounded-lg p-4 mb-6 font-mono text-sm text-primary overflow-x-auto">
+        GET /api/blog/categories/
+      </div>
+    </section>
+
+    <!-- Section 8: Tags -->
+    <section id="tags" class="mb-16 scroll-mt-28 border-t border-outline-variant/10 pt-12">
+      <div class="flex items-center gap-3 mb-6">
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-secondary text-on-secondary uppercase tracking-wider">GET</span>
+        <h2 class="text-2xl font-bold text-primary">List Tags</h2>
+      </div>
+      <p class="text-sm text-on-surface-variant mb-4">Public — no authentication required.</p>
+      <div class="bg-surface-container-low rounded-lg p-4 mb-6 font-mono text-sm text-primary overflow-x-auto">
+        GET /api/blog/tags/
+      </div>
+    </section>
+
+    <!-- Section 9: Comments -->
+    <section id="comments" class="mb-16 scroll-mt-28 border-t border-outline-variant/10 pt-12">
+      <div class="flex items-center gap-3 mb-6">
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-secondary text-on-secondary uppercase tracking-wider">GET</span>
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-tertiary-fixed-dim text-on-tertiary-fixed uppercase tracking-wider">POST</span>
+        <h2 class="text-2xl font-bold text-primary">Comments</h2>
+      </div>
+      <div class="space-y-6">
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">List comments (public):</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">GET /api/blog/&lt;slug&gt;/comments/</div>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">Create comment (auth required):</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">POST /api/blog/&lt;slug&gt;/comments/create/</div>
+          <div class="bg-surface-container-low rounded-lg px-4 py-3 text-sm space-y-1 mt-3">
+            <p><strong>body</strong> — Comment text (required)</p>
+            <p><strong>parent</strong> — Parent comment ID for replies (optional)</p>
+          </div>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">Delete own comment (auth required):</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">DELETE /api/blog/comments/&lt;pk&gt;/delete/</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 10: Likes & Bookmarks -->
+    <section id="interactions" class="mb-16 scroll-mt-28 border-t border-outline-variant/10 pt-12">
+      <div class="flex items-center gap-3 mb-6">
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-tertiary-fixed-dim text-on-tertiary-fixed uppercase tracking-wider">POST</span>
+        <h2 class="text-2xl font-bold text-primary">Likes & Bookmarks</h2>
+      </div>
+      <div class="flex items-center gap-2 mb-6">
+        <span class="material-symbols-outlined text-sm text-secondary">lock</span>
+        <span class="text-xs font-medium text-secondary">All require authentication</span>
+      </div>
+      <div class="space-y-6">
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">Toggle like:</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">POST /api/blog/&lt;slug&gt;/like/</div>
+          <pre class="bg-[#002627] text-[#a3cfcf] p-4 rounded-lg text-xs leading-relaxed overflow-x-auto mt-3">{"liked": true, "count": 25}</pre>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">Toggle bookmark:</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">POST /api/blog/&lt;slug&gt;/bookmark/</div>
+          <pre class="bg-[#002627] text-[#a3cfcf] p-4 rounded-lg text-xs leading-relaxed overflow-x-auto mt-3">{"bookmarked": true}</pre>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">List bookmarked posts:</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">GET /api/blog/bookmarks/</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 11: User Profile -->
+    <section id="profile" class="scroll-mt-28 border-t border-outline-variant/10 pt-12">
+      <div class="flex items-center gap-3 mb-6">
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-secondary text-on-secondary uppercase tracking-wider">GET</span>
+        <span class="px-3 py-1 text-xs font-bold rounded-lg bg-primary-container text-on-primary uppercase tracking-wider">PUT</span>
+        <h2 class="text-2xl font-bold text-primary">User Profile</h2>
+      </div>
+      <div class="space-y-6">
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">Get author profile (public):</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">GET /api/account/profile/&lt;username&gt;/</div>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-on-surface mb-2">Update own profile (auth required):</p>
+          <div class="bg-surface-container-low rounded-lg p-4 font-mono text-sm text-primary overflow-x-auto">PUT /api/account/profile/update/</div>
+          <div class="bg-surface-container-low rounded-lg px-4 py-3 text-sm space-y-1 mt-3">
+            <p><strong>bio</strong> — Text (max 500)</p>
+            <p><strong>location</strong> — e.g. "Lilongwe, Malawi"</p>
+            <p><strong>website</strong> — URL</p>
+            <p><strong>twitter</strong>, <strong>facebook</strong>, <strong>instagram</strong>, <strong>linkedin</strong> — handles</p>
+          </div>
         </div>
       </div>
     </section>
@@ -223,6 +329,21 @@
         </a>
         <a href="#list" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors">
           <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-secondary/20 text-secondary">GET</span> List Posts
+        </a>
+        <a href="#categories" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors">
+          <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-secondary/20 text-secondary">GET</span> Categories
+        </a>
+        <a href="#tags" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors">
+          <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-secondary/20 text-secondary">GET</span> Tags
+        </a>
+        <a href="#comments" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors">
+          <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-tertiary-fixed-dim/20 text-tertiary">MIX</span> Comments
+        </a>
+        <a href="#interactions" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors">
+          <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-tertiary-fixed-dim/20 text-tertiary">POST</span> Likes/Bookmarks
+        </a>
+        <a href="#profile" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors">
+          <span class="px-1.5 py-0.5 text-[10px] font-bold rounded bg-secondary/20 text-secondary">GET</span> Profile
         </a>
       </nav>
 


### PR DESCRIPTION
## Summary
Phase 1 added categories, tags, comments, likes, bookmarks, and user profiles — but only the serializers were updated. This PR adds all the missing API views and URLs.

### New Blog API Endpoints
| Method | Endpoint | Auth | Description |
|--------|----------|------|-------------|
| GET | `/api/blog/categories/` | No | List all categories |
| GET | `/api/blog/tags/` | No | List all tags |
| GET | `/api/blog/<slug>/comments/` | No | List threaded comments |
| POST | `/api/blog/<slug>/comments/create/` | Yes | Create comment |
| DELETE | `/api/blog/comments/<pk>/delete/` | Yes | Delete own comment |
| POST | `/api/blog/<slug>/like/` | Yes | Toggle like |
| POST | `/api/blog/<slug>/bookmark/` | Yes | Toggle bookmark |
| GET | `/api/blog/bookmarks/` | Yes | List bookmarked posts |

### New Account API Endpoints
| Method | Endpoint | Auth | Description |
|--------|----------|------|-------------|
| GET | `/api/account/profile/<username>/` | No | Author profile + stats |
| PUT | `/api/account/profile/update/` | Yes | Update own profile |

### Updated
- `ApiBlogListView` — now supports `?category=<slug>` and `?status=` filtering
- API docs page updated with all 11 new endpoints

## Test plan
- [x] `python manage.py check` — no issues
- [x] `python manage.py test` — 55 tests pass
- [ ] Manual curl test for each new endpoint