### PR TITLE
Fix security vulnerabilities in BlogPost app

### DIFF
--- a/blog/api/serializers.py
+++ b/blog/api/serializers.py
@@ -12,7 +12,7 @@ MIN_BODY_LENGTH = 50
 
 from blog.models import BlogPost, Category, Tag, Comment
 
-from blog.utils import is_image_aspect_ratio_valid, is_image_size_valid
+from blog.utils import is_image_aspect_ratio_valid, is_image_size_valid, validate_image_upload
 
 
 class CategorySerializer(serializers.ModelSerializer):
@@ -93,31 +93,33 @@ class BlogPostUpdateSerializer(serializers.ModelSerializer):
 			title = blog_post['title']
 			if len(title) < MIN_TITLE_LENGTH:
 				raise serializers.ValidationError({"response": "Enter a title longer than " + str(MIN_TITLE_LENGTH) + " characters."})
-			
+
 			body = blog_post['body']
 			if len(body) < MIN_BODY_LENGTH:
 				raise serializers.ValidationError({"response": "Enter a body longer than " + str(MIN_BODY_LENGTH) + " characters."})
-			
+		except KeyError:
+			pass
+
+		try:
 			image = blog_post['image']
-			url = os.path.join(settings.TEMP , str(image))
+
+			# Validate MIME type and size before writing to disk
+			is_valid, error_msg = validate_image_upload(image)
+			if not is_valid:
+				raise serializers.ValidationError({"response": error_msg})
+
+			url = os.path.join(settings.TEMP, str(image))
 			storage = FileSystemStorage(location=url)
+			try:
+				with storage.open('', 'wb+') as destination:
+					for chunk in image.chunks():
+						destination.write(chunk)
 
-			with storage.open('', 'wb+') as destination:
-				for chunk in image.chunks():
-					destination.write(chunk)
-				destination.close()
-
-			# Check image size
-			if not is_image_size_valid(url, IMAGE_SIZE_MAX_BYTES):
-				os.remove(url)
-				raise serializers.ValidationError({"response": "That image is too large. Images must be less than 2 MB. Try a different image."})
-
-			# Check image aspect ratio
-			if not is_image_aspect_ratio_valid(url):
-				os.remove(url)
-				raise serializers.ValidationError({"response": "Image height must not exceed image width. Try a different image."})
-
-			os.remove(url)
+				if not is_image_aspect_ratio_valid(url):
+					raise serializers.ValidationError({"response": "Image height must not exceed image width. Try a different image."})
+			finally:
+				if os.path.exists(url):
+					os.remove(url)
 		except KeyError:
 			pass
 		return blog_post
@@ -133,17 +135,21 @@ class BlogPostCreateSerializer(serializers.ModelSerializer):
 
 
 	def save(self):
-		
 		try:
 			image = self.validated_data['image']
 			title = self.validated_data['title']
 			if len(title) < MIN_TITLE_LENGTH:
 				raise serializers.ValidationError({"response": "Enter a title longer than " + str(MIN_TITLE_LENGTH) + " characters."})
-			
+
 			body = self.validated_data['body']
 			if len(body) < MIN_BODY_LENGTH:
 				raise serializers.ValidationError({"response": "Enter a body longer than " + str(MIN_BODY_LENGTH) + " characters."})
-			
+
+			# Validate MIME type and size before writing to disk
+			is_valid, error_msg = validate_image_upload(image)
+			if not is_valid:
+				raise serializers.ValidationError({"response": error_msg})
+
 			blog_post = BlogPost(
 								author=self.validated_data['author'],
 								title=title,
@@ -151,25 +157,19 @@ class BlogPostCreateSerializer(serializers.ModelSerializer):
 								image=image,
 								)
 
-			url = os.path.join(settings.TEMP , str(image))
+			url = os.path.join(settings.TEMP, str(image))
 			storage = FileSystemStorage(location=url)
+			try:
+				with storage.open('', 'wb+') as destination:
+					for chunk in image.chunks():
+						destination.write(chunk)
 
-			with storage.open('', 'wb+') as destination:
-				for chunk in image.chunks():
-					destination.write(chunk)
-				destination.close()
+				if not is_image_aspect_ratio_valid(url):
+					raise serializers.ValidationError({"response": "Image height must not exceed image width. Try a different image."})
+			finally:
+				if os.path.exists(url):
+					os.remove(url)
 
-			# Check image size
-			if not is_image_size_valid(url, IMAGE_SIZE_MAX_BYTES):
-				os.remove(url)
-				raise serializers.ValidationError({"response": "That image is too large. Images must be less than 2 MB. Try a different image."})
-
-			# Check image aspect ratio
-			if not is_image_aspect_ratio_valid(url):
-				os.remove(url)
-				raise serializers.ValidationError({"response": "Image height must not exceed image width. Try a different image."})
-
-			os.remove(url)
 			blog_post.save()
 			return blog_post
 		except KeyError:

--- a/blog/api/views.py
+++ b/blog/api/views.py
@@ -157,13 +157,16 @@ class ApiBlogListView(ListAPIView):
 	ordering_fields = ('date_updated', 'view_count', 'title')
 
 	def get_queryset(self):
-		queryset = BlogPost.objects.all()
+		if self.request.user.is_staff:
+			queryset = BlogPost.objects.all()
+			status_filter = self.request.query_params.get('status')
+			if status_filter:
+				queryset = queryset.filter(status=status_filter)
+		else:
+			queryset = BlogPost.objects.filter(status='published')
 		category = self.request.query_params.get('category')
-		status_filter = self.request.query_params.get('status')
 		if category:
 			queryset = queryset.filter(category__slug=category)
-		if status_filter:
-			queryset = queryset.filter(status=status_filter)
 		return queryset
 
 

--- a/blog/templates/blog/detail_blog.html
+++ b/blog/templates/blog/detail_blog.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load sanitize %}
 
 {% block title %}{{ blog_post.title }} | NyasaBlog{% endblock %}
 
@@ -70,7 +71,7 @@
     {% endif %}
 
     <!-- Article Body -->
-    <div class="prose prose-lg max-w-none mb-12 text-on-surface">{{ blog_post.body|safe }}</div>
+    <div class="prose prose-lg max-w-none mb-12 text-on-surface">{{ blog_post.body|sanitize_html }}</div>
 
     <!-- Tags -->
     {% if blog_post.tags.all %}

--- a/blog/templatetags/sanitize.py
+++ b/blog/templatetags/sanitize.py
@@ -1,0 +1,38 @@
+import nh3
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+ALLOWED_TAGS = {
+    "a", "abbr", "acronym", "b", "blockquote", "br", "code", "em",
+    "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "li",
+    "ol", "p", "pre", "strong", "sub", "sup", "table", "tbody",
+    "td", "th", "thead", "tr", "u", "ul", "figure", "figcaption",
+    "div", "span", "iframe",
+}
+
+ALLOWED_ATTRIBUTES = {
+    "*": {"class", "style"},
+    "a": {"href", "title", "target", "rel"},
+    "img": {"src", "alt", "width", "height", "loading"},
+    "iframe": {"src", "width", "height", "frameborder", "allowfullscreen"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan"},
+}
+
+ALLOWED_URL_SCHEMES = {"http", "https", "mailto"}
+
+
+@register.filter(name="sanitize_html")
+def sanitize_html(value):
+    if not value:
+        return ""
+    cleaned = nh3.clean(
+        value,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        url_schemes=ALLOWED_URL_SCHEMES,
+        link_rel="noopener noreferrer",
+    )
+    return mark_safe(cleaned)

--- a/blog/utils.py
+++ b/blog/utils.py
@@ -1,12 +1,15 @@
 import cv2
 import os
 
+ALLOWED_IMAGE_TYPES = {'image/jpeg', 'image/png', 'image/webp', 'image/gif'}
+
+
 def is_image_aspect_ratio_valid(img_url):
 	img = cv2.imread(img_url)
+	if img is None:
+		return False
 	dimensions = tuple(img.shape[1::-1]) # gives: (width, height)
-	#print("dimensions: " + str(dimensions))
 	aspect_ratio = dimensions[0] / dimensions[1] # divide w / h
-	#print("aspect_ratio: " + str(aspect_ratio))
 	if aspect_ratio < 1:
 		return False
 	return True
@@ -14,7 +17,15 @@ def is_image_aspect_ratio_valid(img_url):
 
 def is_image_size_valid(img_url, mb_limit):
 	image_size = os.path.getsize(img_url)
-	#print("image size: " + str(image_size))
 	if image_size > mb_limit:
 		return False
 	return True
+
+
+def validate_image_upload(image):
+	"""Validate image MIME type and size before writing to disk."""
+	if hasattr(image, 'content_type') and image.content_type not in ALLOWED_IMAGE_TYPES:
+		return False, "Unsupported image format. Allowed: JPEG, PNG, WebP, GIF."
+	if hasattr(image, 'size') and image.size > 2 * 1024 * 1024:
+		return False, "Image too large. Images must be less than 2 MB."
+	return True, None

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,17 +1,16 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Q, F, Count
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponseForbidden, JsonResponse
 from django.views.decorators.http import require_POST
+from django.contrib.auth.decorators import login_required
 
 from blog.models import BlogPost, Category, Comment, Like, Bookmark
 from blog.forms import CreateBlogPostForm, UpdateBlogPostForm, CommentForm
 
 
+@login_required(login_url='must_authenticate')
 def create_blog_view(request):
 	context = {}
-	user = request.user
-	if not user.is_authenticated:
-		return redirect('must_authenticate')
 
 	form = CreateBlogPostForm(request.POST or None, request.FILES or None)
 	if form.is_valid():
@@ -77,15 +76,13 @@ def detail_blog_view(request, slug):
 	return render(request, 'blog/detail_blog.html', context)
 
 
+@login_required(login_url='must_authenticate')
 def edit_blog_view(request, slug):
 	context = {}
-	user = request.user
-	if not user.is_authenticated:
-		return redirect("must_authenticate")
 
 	blog_post = get_object_or_404(BlogPost, slug=slug)
-	if blog_post.author != user:
-		return HttpResponse('You are not the author of that post.')
+	if blog_post.author != request.user:
+		return HttpResponseForbidden('You are not the author of that post.')
 
 	if request.POST:
 		form = UpdateBlogPostForm(request.POST or None, request.FILES or None, instance=blog_post)
@@ -116,12 +113,11 @@ def get_blog_queryset(query=None):
 	return BlogPost.objects.filter(q_objects, status='published').distinct()
 
 
+@login_required(login_url='must_authenticate')
 def delete_blog_post(request, pk):
-	if not request.user.is_authenticated:
-		return redirect('must_authenticate')
 	post = get_object_or_404(BlogPost, id=pk)
 	if post.author != request.user:
-		return HttpResponse('You are not the author of that post.')
+		return HttpResponseForbidden('You are not the author of that post.')
 	if request.method == 'POST':
 		post.delete()
 		return redirect('home')
@@ -129,12 +125,11 @@ def delete_blog_post(request, pk):
 	return render(request, 'blog/post_delete.html', context)
 
 
+@login_required(login_url='must_authenticate')
 def delete_comment_view(request, pk):
-	if not request.user.is_authenticated:
-		return redirect('must_authenticate')
 	comment = get_object_or_404(Comment, pk=pk)
 	if comment.author != request.user:
-		return HttpResponse('You are not the author of this comment.')
+		return HttpResponseForbidden('You are not the author of this comment.')
 	slug = comment.post.slug
 	if request.method == 'POST':
 		comment.delete()
@@ -169,9 +164,8 @@ def toggle_bookmark_view(request, slug):
 	return JsonResponse({'bookmarked': bookmarked})
 
 
+@login_required(login_url='login')
 def bookmarks_view(request):
-	if not request.user.is_authenticated:
-		return redirect('login')
 	bookmarked_posts = BlogPost.objects.filter(
 		bookmarks__user=request.user
 	).select_related('author', 'category').order_by('-bookmarks__created_at')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-storages==1.12.3
 djangorestframework==3.17.1
 gunicorn==25.3.0
 jmespath==1.0.0
+nh3==0.3.4
 numpy==2.4.4
 opencv-python-headless==4.13.0.92
 Pillow==12.2.0


### PR DESCRIPTION
- Fix stored XSS: replace |safe with nh3-based sanitize_html template filter
- Fix file uploads: add MIME type validation, pre-write size checks, try/finally cleanup
- Fix API draft exposure: default queryset to published posts for non-staff users
- Fix auth responses: return 403 Forbidden instead of 200 OK on authorization failures
- Add @login_required decorators to replace manual is_authenticated checks