### PR TITLE
Add HTMX foundation: django-htmx, CSRF config, toast system, auth guard

### DIFF
--- a/HTMX_REFACTOR.md
+++ b/HTMX_REFACTOR.md
@@ -1,0 +1,180 @@
+# HTMX Integration Refactor — NyasaBlog
+
+Tracking document for migrating NyasaBlog from a traditional server-rendered Django app to a reactive HTMX-powered experience.
+
+**Base branch**: `master`
+**Started**: 2026-04-08
+
+---
+
+## Phase Sequence
+
+| Phase | Branch | Description | Status |
+|-------|--------|-------------|--------|
+| 0 | `htmx/phase-0-foundation` | Foundation + Toast + Auth Guard + CSRF | Pending |
+| 1 | `htmx/phase-1-likes-bookmarks` | Likes & Bookmarks (validates setup) | Pending |
+| 2 | `htmx/phase-2-newsletter` | Newsletter Subscribe | Pending |
+| 3 | `htmx/phase-3-comments` | Comments (submit, delete, OOB count) | Pending |
+| 4 | `htmx/phase-4-pagination` | Pagination / Infinite Scroll | Pending |
+| 5 | `htmx/phase-5-category-filter` | Category Filtering (explicit ?partial=) | Pending |
+| 6 | `htmx/phase-6-live-search` | Live Search (header dropdown + page) | Pending |
+| 7 | `htmx/phase-7-forms` | Form Submissions (login, register, contact, account) | Pending |
+| 8 | `htmx/phase-8-cleanup` | Cleanup (remove dead JS, add indicators) | Pending |
+
+---
+
+## Key Architectural Decisions
+
+1. **HX-Trigger for toasts** — not OOB HTML appended to every response. Single global JS listener.
+2. **`@htmx_login_required` decorator** — returns 401 + `HX-Reswap: none` + toast for unauthenticated HTMX requests. Prevents login page HTML from being swapped into a button target.
+3. **Explicit `?partial=` query param** — for differentiating partial responses (e.g., pagination vs. category filtering). More resilient than `request.htmx.target`.
+4. **Progressive enhancement** — partials are `{% include %}`d in parent templates, so the site works without JS.
+5. **JSON API preserved** — views branch on `request.htmx`; DRF API and future mobile clients unaffected.
+6. **CKEditor forms stay traditional** — CKEditor DOM state doesn't survive HTMX swaps.
+7. **No `hx-boost`** — too much risk for admin, CKEditor, third-party pages. Per-element HTMX is sufficient.
+
+---
+
+## Phase 0: Foundation
+
+### Changes
+- `requirements.txt` — add `django-htmx`
+- `mysite/settings.py` — add `django_htmx` to `INSTALLED_APPS`, add `HtmxMiddleware`
+- `templates/base.html` — add HTMX script, CSRF config, toast container, global error handler
+- `templates/snippets/base_css.html` — add htmx-indicator + toast animation CSS
+- `blog/utils.py` — `trigger_toast()` helper, `@htmx_login_required` decorator
+- Create `partials/` directories
+
+### Verification
+- [ ] HTMX loads on every page (check Network tab)
+- [ ] `request.htmx` is available in views (add a print statement)
+- [ ] CSRF token is sent with HTMX POST requests
+- [ ] Toast fires from browser console: `document.body.dispatchEvent(new CustomEvent('showToast', {detail: {message: 'Test', type: 'success'}}))`
+
+---
+
+## Phase 1: Likes & Bookmarks
+
+### Changes
+- `blog/templates/blog/partials/like_button.html` — new partial
+- `blog/templates/blog/partials/bookmark_button.html` — new partial
+- `blog/views.py` — modify `toggle_like_view`, `toggle_bookmark_view` to return partials for HTMX
+- `blog/templates/blog/detail_blog.html` — replace inline buttons with `{% include %}`, delete `toggleLike`/`toggleBookmark` JS
+- `blog/templates/blog/bookmarks.html` — replace inline `fetch()` with `hx-post`
+
+### Verification
+- [ ] Like toggles without page reload, count updates, toast shows
+- [ ] Bookmark toggles without page reload, toast shows
+- [ ] Bookmark removal on bookmarks page removes the card with transition
+- [ ] Unauthenticated user sees toast "Please log in" instead of broken swap
+- [ ] JSON API still works (`curl -X POST`)
+
+---
+
+## Phase 2: Newsletter Subscribe
+
+### Changes
+- `personal/views.py` — modify `subscribe_view` for HTMX
+- Multiple templates — replace `submitNewsletter()` with `hx-post` forms
+- `templates/base.html` — delete `submitNewsletter` function
+
+### Verification
+- [ ] Subscribe works without page reload
+- [ ] Duplicate email shows "already subscribed" message
+- [ ] Empty email shows error
+
+---
+
+## Phase 3: Comments
+
+### Changes
+- `blog/templates/blog/partials/comment_item.html` — new
+- `blog/templates/blog/partials/comment_form.html` — new
+- `blog/templates/blog/partials/reply_item.html` — new
+- `blog/urls.py` — add `comment_create` URL
+- `blog/views.py` — add `htmx_create_comment_view`, modify `delete_comment_view`
+- `blog/templates/blog/detail_blog.html` — HTMX comment form + list
+
+### Verification
+- [ ] Comment submits without reload, appears at top of list, form resets
+- [ ] Reply submits without reload, appears under parent
+- [ ] Comment delete removes element, shows confirm dialog
+- [ ] Comment count updates via OOB swap
+- [ ] Unauthenticated user gets toast, not broken swap
+
+---
+
+## Phase 4: Pagination / Infinite Scroll
+
+### Changes
+- `personal/templates/personal/partials/post_grid.html` — new
+- `personal/views.py` — modify `home_screen_view`
+- `personal/templates/personal/home.html` — use `{% include %}`, remove pagination block
+
+### Verification
+- [ ] Scrolling to bottom loads more posts
+- [ ] Last page doesn't show loading sentinel
+- [ ] Initial page load still works without JS
+
+---
+
+## Phase 5: Category Filtering
+
+### Changes
+- `personal/templates/personal/partials/home_content.html` — new
+- `personal/templates/personal/home.html` — HTMX category pills with `hx-vals`
+- `personal/views.py` — differentiate via `?partial=` param
+
+### Verification
+- [ ] Clicking a category filters posts without reload
+- [ ] URL updates via `hx-push-url`
+- [ ] Back button works correctly
+- [ ] Direct URL access still renders full page
+
+---
+
+## Phase 6: Live Search
+
+### Changes
+- `personal/templates/personal/partials/search_dropdown.html` — new
+- `templates/snippets/header.html` — HTMX search input
+- `personal/views.py` — modify `search_view` for dropdown partial
+
+### Verification
+- [ ] Typing in header search shows dropdown after 300ms
+- [ ] Results update as you type
+- [ ] Clicking a result navigates to the post
+- [ ] "View all results" links to full search page
+
+---
+
+## Phase 7: Form Submissions
+
+### Changes
+- `account/templates/account/partials/login_form.html` — new
+- `account/templates/account/partials/register_form.html` — new
+- `personal/templates/personal/partials/contact_success.html` — new
+- `account/views.py` — modify login, register, account views
+- `personal/views.py` — modify contact view
+- Template files — add `hx-post` attributes
+
+### Verification
+- [ ] Login errors show inline without reload
+- [ ] Successful login redirects via `HX-Redirect`
+- [ ] Registration errors show inline
+- [ ] Contact form shows success message without reload
+- [ ] Account settings saves with file upload
+
+---
+
+## Phase 8: Cleanup
+
+### Changes
+- Remove all dead inline JS
+- Add `hx-indicator` spinners to all HTMX forms
+- Final review of all templates for missed opportunities
+
+### Verification
+- [ ] No inline `fetch()` calls remain (except theme toggle)
+- [ ] Loading indicators visible during slow requests
+- [ ] All pages functional with and without JS

--- a/blog/utils.py
+++ b/blog/utils.py
@@ -1,5 +1,10 @@
 import cv2
 import os
+from functools import wraps
+
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from django_htmx.http import trigger_client_event
 
 ALLOWED_IMAGE_TYPES = {'image/jpeg', 'image/png', 'image/webp', 'image/gif'}
 
@@ -29,3 +34,25 @@ def validate_image_upload(image):
 	if hasattr(image, 'size') and image.size > 2 * 1024 * 1024:
 		return False, "Image too large. Images must be less than 2 MB."
 	return True, None
+
+
+def trigger_toast(response, message, toast_type='success'):
+	"""Attach an HX-Trigger header that fires the showToast custom event."""
+	return trigger_client_event(response, 'showToast', {'message': message, 'type': toast_type})
+
+
+def htmx_login_required(view_func):
+	"""Decorator that returns a 401 + toast for unauthenticated HTMX requests
+	instead of redirecting to the login page (which would swap login HTML
+	into the button target)."""
+	@wraps(view_func)
+	def wrapper(request, *args, **kwargs):
+		if not request.user.is_authenticated:
+			if getattr(request, 'htmx', False):
+				response = HttpResponse(status=401)
+				response['HX-Reswap'] = 'none'
+				trigger_toast(response, 'Please log in to continue', 'error')
+				return response
+			return redirect('must_authenticate')
+		return view_func(request, *args, **kwargs)
+	return wrapper

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'storages',
     'rest_framework',
     'rest_framework.authtoken',
+    'django_htmx',
     
    
 ]
@@ -82,6 +83,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_htmx.middleware.HtmxMiddleware',
 ]
 
 ROOT_URLCONF = 'mysite.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six==1.17.0
 sqlparse==0.5.5
 urllib3==2.6.3
 whitenoise==6.2.0
+django-htmx==1.21.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,7 @@
 })();
 </script>
 {% block extra_head %}{% endblock %}
+<script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>  {# pragma: allowlist secret #}
 </head>
 <body class="bg-background text-on-surface font-body selection:bg-secondary-container selection:text-on-secondary-container transition-colors duration-300">
 
@@ -34,7 +35,52 @@
 
 {% include 'snippets/footer.html' %}
 
+<!-- Toast container -->
+<div id="toast-container" class="fixed top-20 right-6 z-[60] space-y-3 pointer-events-none"></div>
+
 {% block extra_js %}{% endblock %}
+<script>
+// CSRF token helper (Django docs pattern)
+function getCookie(name) {
+    var v = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
+    return v ? v.pop() : '';
+}
+// HTMX CSRF token for all requests
+document.body.addEventListener('htmx:configRequest', function(e) {
+    e.detail.headers['X-CSRFToken'] = getCookie('csrftoken');
+});
+
+// Toast system — views fire HX-Trigger: {"showToast": {"message": "...", "type": "..."}}
+var MAX_TOASTS = 5;
+document.body.addEventListener('showToast', function(e) {
+    var container = document.getElementById('toast-container');
+    // Cap visible toasts
+    while (container.children.length >= MAX_TOASTS) {
+        container.removeChild(container.firstChild);
+    }
+    var d = e.detail;
+    var isError = d.type === 'error';
+    var toast = document.createElement('div');
+    toast.className = 'pointer-events-auto px-6 py-4 rounded-xl shadow-lg flex items-center gap-3 text-sm font-medium animate-slide-in '
+        + (isError ? 'bg-error-container text-on-error-container' : 'bg-primary-container text-on-primary-container');
+    var icon = document.createElement('span');
+    icon.className = 'material-symbols-outlined text-base';
+    icon.textContent = isError ? 'error' : 'check_circle';
+    var msg = document.createElement('span');
+    msg.textContent = d.message;
+    toast.appendChild(icon);
+    toast.appendChild(msg);
+    container.appendChild(toast);
+    setTimeout(function() { if (toast.parentNode) toast.remove(); }, 5000);
+});
+
+// Global HTMX error handler
+document.body.addEventListener('htmx:responseError', function() {
+    document.body.dispatchEvent(new CustomEvent('showToast', {
+        detail: { message: 'Something went wrong. Please try again.', type: 'error' }
+    }));
+});
+</script>
 <script>
 function toggleTheme() {
   var html = document.documentElement;

--- a/templates/snippets/base_css.html
+++ b/templates/snippets/base_css.html
@@ -84,4 +84,15 @@
     .hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
     .no-scrollbar::-webkit-scrollbar { display: none; }
     .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+    /* HTMX indicators */
+    .htmx-indicator { display: none; }
+    .htmx-request .htmx-indicator, .htmx-request.htmx-indicator { display: inline-block; }
+
+    /* Toast slide-in animation */
+    @keyframes slide-in-right {
+        from { transform: translateX(100%); opacity: 0; }
+        to { transform: translateX(0); opacity: 1; }
+    }
+    .animate-slide-in { animation: slide-in-right 0.3s ease-out; }
 </style>


### PR DESCRIPTION
- Install django-htmx and add HtmxMiddleware
- Add HTMX 2.0.4 script to base template
- Configure CSRF token for all HTMX requests using getCookie pattern
- Add toast notification system via HX-Trigger events with XSS-safe rendering
- Add @htmx_login_required decorator for auth-gated HTMX endpoints
- Add trigger_toast helper using django_htmx.http.trigger_client_event
- Add HTMX indicator CSS and toast slide-in animation
- Add HTMX_REFACTOR.md tracking document