### PR TITLE
Add HTMX like and bookmark toggles, remove inline JS

### DIFF
--- a/blog/templates/blog/bookmarks.html
+++ b/blog/templates/blog/bookmarks.html
@@ -34,7 +34,11 @@
         <p class="text-sm text-on-surface-variant line-clamp-2 mb-4">{{ post.body|striptags|truncatechars:100 }}</p>
         <div class="flex items-center justify-between text-xs text-on-surface-variant">
           <span>{{ post.author.username }} · {{ post.reading_time }} min</span>
-          <button onclick="fetch('/blog/{{ post.slug }}/bookmark/', {method:'POST', headers:{'X-CSRFToken':'{{ csrf_token }}'}, credentials:'same-origin'}).then(()=>this.closest('article').remove())"
+          <button hx-post="{% url 'blog:bookmark' post.slug %}"
+                  hx-target="closest article"
+                  hx-swap="outerHTML swap:0.3s"
+                  hx-confirm="Remove bookmark?"
+                  id="bookmark-remove-{{ post.slug }}"
                   class="p-1 text-on-surface-variant hover:text-error transition-colors" title="Remove bookmark">
             <span class="material-symbols-outlined text-lg">bookmark_remove</span>
           </button>

--- a/blog/templates/blog/detail_blog.html
+++ b/blog/templates/blog/detail_blog.html
@@ -17,14 +17,9 @@
 
   <!-- Sticky Side Actions (Desktop) -->
   <aside class="hidden lg:flex lg:col-span-1 flex-col items-center gap-4 sticky top-28 self-start pt-8">
-    <button onclick="toggleLike('{{ blog_post.slug }}')" class="p-3 rounded-[10px] hover:bg-surface-container-low transition-colors {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
-      <span class="material-symbols-outlined like-icon" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
-    </button>
-    <span class="text-xs text-on-surface-variant like-count">{{ like_count }}</span>
+    {% include 'blog/partials/like_button.html' %}
     <div class="w-px h-8 bg-outline-variant/30"></div>
-    <button onclick="toggleBookmark('{{ blog_post.slug }}')" class="p-3 rounded-[10px] hover:bg-surface-container-low transition-colors {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
-      <span class="material-symbols-outlined bookmark-icon" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
-    </button>
+    {% include 'blog/partials/bookmark_button.html' %}
     <div class="w-px h-8 bg-outline-variant/30"></div>
     <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="p-3 rounded-[10px] text-[#25D366] hover:bg-surface-container-low transition-colors">
       <span class="material-symbols-outlined">share</span>
@@ -52,13 +47,8 @@
       </div>
       <!-- Mobile Social -->
       <div class="flex lg:hidden items-center gap-2 ml-auto">
-        <button onclick="toggleLike('{{ blog_post.slug }}')" class="p-2 {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
-          <span class="material-symbols-outlined text-xl like-icon" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
-        </button>
-        <span class="text-xs text-on-surface-variant like-count">{{ like_count }}</span>
-        <button onclick="toggleBookmark('{{ blog_post.slug }}')" class="p-2 {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
-          <span class="material-symbols-outlined text-xl bookmark-icon" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
-        </button>
+        {% include 'blog/partials/like_button_mobile.html' %}
+        {% include 'blog/partials/bookmark_button_mobile.html' %}
         <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="p-2 text-[#25D366]">
           <span class="material-symbols-outlined text-xl">share</span>
         </a>
@@ -207,28 +197,4 @@
 </div>
 </div>
 
-<script>
-function toggleAction(slug, action, iconClass, countClass) {
-  fetch('/blog/' + slug + '/' + action + '/', {
-    method: 'POST',
-    headers: {'X-CSRFToken': '{{ csrf_token }}'},
-    credentials: 'same-origin'
-  })
-  .then(function(r) { if (r.status === 401) { window.location.href = '{% url "login" %}'; throw 'redirect'; } if (!r.ok) throw new Error(r.status); return r.json(); })
-  .then(function(data) {
-    var active = data.liked !== undefined ? data.liked : data.bookmarked;
-    document.querySelectorAll('.' + iconClass).forEach(function(el) {
-      el.style.fontVariationSettings = active ? "'FILL' 1" : "'FILL' 0";
-    });
-    if (countClass && data.count !== undefined) {
-      document.querySelectorAll('.' + countClass).forEach(function(el) {
-        el.textContent = data.count;
-      });
-    }
-  })
-  .catch(function(e) { if (e !== 'redirect') console.error(e); });
-}
-function toggleLike(slug) { toggleAction(slug, 'like', 'like-icon', 'like-count'); }
-function toggleBookmark(slug) { toggleAction(slug, 'bookmark', 'bookmark-icon', null); }
-</script>
 {% endblock content %}

--- a/blog/templates/blog/partials/bookmark_button.html
+++ b/blog/templates/blog/partials/bookmark_button.html
@@ -1,0 +1,9 @@
+<div id="bookmark-btn"
+     hx-post="{% url 'blog:bookmark' blog_post.slug %}"
+     hx-target="this"
+     hx-swap="outerHTML">
+  <button type="button"
+          class="p-3 rounded-[10px] hover:bg-surface-container-low transition-colors {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
+  </button>
+</div>

--- a/blog/templates/blog/partials/bookmark_button_mobile.html
+++ b/blog/templates/blog/partials/bookmark_button_mobile.html
@@ -1,0 +1,9 @@
+<div id="bookmark-btn-mobile"
+     hx-post="{% url 'blog:bookmark' blog_post.slug %}?variant=mobile"
+     hx-target="this"
+     hx-swap="outerHTML">
+  <button type="button"
+          class="p-2 {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined text-xl" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
+  </button>
+</div>

--- a/blog/templates/blog/partials/like_button.html
+++ b/blog/templates/blog/partials/like_button.html
@@ -1,0 +1,10 @@
+<div class="flex flex-col items-center gap-1" id="like-btn"
+     hx-post="{% url 'blog:like' blog_post.slug %}"
+     hx-target="this"
+     hx-swap="outerHTML">
+  <button type="button"
+          class="p-3 rounded-[10px] hover:bg-surface-container-low transition-colors {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
+  </button>
+  <span class="text-xs text-on-surface-variant">{{ like_count }}</span>
+</div>

--- a/blog/templates/blog/partials/like_button_mobile.html
+++ b/blog/templates/blog/partials/like_button_mobile.html
@@ -1,0 +1,10 @@
+<div class="flex items-center gap-1" id="like-btn-mobile"
+     hx-post="{% url 'blog:like' blog_post.slug %}?variant=mobile"
+     hx-target="this"
+     hx-swap="outerHTML">
+  <button type="button"
+          class="p-2 {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined text-xl" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
+  </button>
+  <span class="text-xs text-on-surface-variant">{{ like_count }}</span>
+</div>

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -175,7 +175,8 @@ class LikeToggleViewTests(ModelTestMixin, TestCase):
 
 	def test_like_requires_auth(self):
 		response = self.client.post(reverse('blog:like', args=[self.post.slug]))
-		self.assertEqual(response.status_code, 401)
+		# @htmx_login_required redirects non-HTMX unauthenticated requests
+		self.assertEqual(response.status_code, 302)
 
 	def test_like_toggle(self):
 		self.client.login(email='test@nyasablog.com', password='testpass123')

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,11 +1,12 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Q, F, Count
-from django.http import HttpResponseForbidden, JsonResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.views.decorators.http import require_POST
 from django.contrib.auth.decorators import login_required
 
 from blog.models import BlogPost, Category, Comment, Like, Bookmark
 from blog.forms import CreateBlogPostForm, UpdateBlogPostForm, CommentForm
+from blog.utils import htmx_login_required, trigger_toast
 
 
 @login_required(login_url='must_authenticate')
@@ -137,9 +138,8 @@ def delete_comment_view(request, pk):
 
 
 @require_POST
+@htmx_login_required
 def toggle_like_view(request, slug):
-	if not request.user.is_authenticated:
-		return JsonResponse({'error': 'Login required'}, status=401)
 	post = get_object_or_404(BlogPost, slug=slug)
 	like, created = Like.objects.get_or_create(post=post, user=request.user)
 	if not created:
@@ -147,20 +147,52 @@ def toggle_like_view(request, slug):
 		liked = False
 	else:
 		liked = True
+
+	if request.htmx:
+		variant = request.GET.get('variant', 'desktop')
+		template = 'blog/partials/like_button.html'
+		if variant == 'mobile':
+			template = 'blog/partials/like_button_mobile.html'
+		response = render(request, template, {
+			'blog_post': post,
+			'is_liked': liked,
+			'like_count': post.likes.count(),
+		})
+		trigger_toast(response, 'Liked!' if liked else 'Like removed')
+		return response
 	return JsonResponse({'liked': liked, 'count': post.likes.count()})
 
 
 @require_POST
+@htmx_login_required
 def toggle_bookmark_view(request, slug):
-	if not request.user.is_authenticated:
-		return JsonResponse({'error': 'Login required'}, status=401)
 	post = get_object_or_404(BlogPost, slug=slug)
+
+	# Bookmarks page removal — skip toggle, just delete
+	if request.htmx and request.htmx.trigger and request.htmx.trigger.startswith('bookmark-remove-'):
+		post.bookmarks.filter(user=request.user).delete()
+		response = HttpResponse(status=200)
+		trigger_toast(response, 'Bookmark removed')
+		return response
+
 	bookmark, created = Bookmark.objects.get_or_create(post=post, user=request.user)
 	if not created:
 		bookmark.delete()
 		bookmarked = False
 	else:
 		bookmarked = True
+
+	if request.htmx:
+		variant = request.GET.get('variant', 'desktop')
+		template = 'blog/partials/bookmark_button.html'
+		if variant == 'mobile':
+			template = 'blog/partials/bookmark_button_mobile.html'
+		response = render(request, template, {
+			'blog_post': post,
+			'is_bookmarked': bookmarked,
+		})
+		trigger_toast(response, 'Bookmarked!' if bookmarked else 'Bookmark removed')
+		return response
 	return JsonResponse({'bookmarked': bookmarked})
 
 


### PR DESCRIPTION
- Create like/bookmark button partials (desktop + mobile variants)
- Modify toggle_like_view and toggle_bookmark_view to return HTML partials for HTMX requests, keep JSON for API clients
- Use @htmx_login_required for auth-gated endpoints with toast feedback
- Use ?variant=mobile query param for mobile/desktop partial selection
- Fix bookmark-remove to use direct .filter().delete() before get_or_create
- Replace inline toggleAction/toggleLike/toggleBookmark JS with HTMX
- Replace inline fetch() in bookmarks page with hx-post