### PR TITLE
Htmx/phase 3 comments

### DIFF
--- a/account/templates/account/author_profile.html
+++ b/account/templates/account/author_profile.html
@@ -177,11 +177,11 @@
       <section class="bg-[#0f3d3e] p-6 md:p-8 rounded-xl text-white">
         <h4 class="text-xl font-bold mb-2">The Weekly Pulse</h4>
         <p class="text-sm text-white/80 mb-6 leading-relaxed">Subscribe for stories from {{ author.username }} and the NyasaBlog community.</p>
-        <div class="space-y-3">
-          <input id="newsletter-email-profile" class="w-full px-4 py-3 rounded-lg bg-white/10 border-none text-white placeholder:text-white/50 focus:ring-2 focus:ring-tertiary-fixed-dim text-sm" placeholder="Email address" type="email"/>
-          <button onclick="submitNewsletter('newsletter-email-profile', 'newsletter-msg-profile')" class="w-full py-3 bg-tertiary-fixed-dim text-[#002627] font-bold rounded-lg hover:opacity-90 transition-opacity">Subscribe</button>
-          <p id="newsletter-msg-profile" class="text-xs text-white/70 hidden"></p>
-        </div>
+        <form hx-post="{% url 'subscribe' %}" hx-target="#newsletter-msg-profile" hx-swap="innerHTML" hx-on::after-request="if(event.detail.successful) this.reset()" class="space-y-3">
+          <input name="email" class="w-full px-4 py-3 rounded-lg bg-white/10 border-none text-white placeholder:text-white/50 focus:ring-2 focus:ring-tertiary-fixed-dim text-sm" placeholder="Email address" type="email"/>
+          <button type="submit" class="w-full py-3 bg-tertiary-fixed-dim text-[#002627] font-bold rounded-lg hover:opacity-90 transition-opacity">Subscribe</button>
+        </form>
+        <p id="newsletter-msg-profile" class="text-xs text-white/70 empty:hidden"></p>
       </section>
     </aside>
 

--- a/blog/templates/blog/detail_blog.html
+++ b/blog/templates/blog/detail_blog.html
@@ -100,11 +100,14 @@
 
     <!-- Comments -->
     <section class="mb-12">
-      <h2 class="text-2xl font-black text-primary mb-6">Comments ({{ comment_count }})</h2>
+      <h2 class="text-2xl font-black text-primary mb-6">Comments (<span id="comment-count">{{ comment_count }}</span>)</h2>
 
       {% if request.user.is_authenticated %}
-      <form method="POST" class="mb-8">
-        {% csrf_token %}
+      <form hx-post="{% url 'blog:comment_create' blog_post.slug %}"
+            hx-target="#comment-list"
+            hx-swap="afterbegin"
+            hx-on::after-request="if(event.detail.successful) this.reset()"
+            class="mb-8">
         <textarea name="body" rows="3" placeholder="Write a comment..." class="w-full bg-surface-container-lowest border border-outline-variant/20 rounded-xl py-3 px-4 text-sm focus:ring-2 focus:ring-secondary/20 focus:border-secondary resize-none"></textarea>
         <button type="submit" class="mt-3 bg-primary-container text-on-primary px-6 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity">Post Comment</button>
       </form>
@@ -112,49 +115,13 @@
       <p class="text-sm text-on-surface-variant mb-8"><a href="{% url 'login' %}" class="text-secondary font-medium">Sign in</a> to leave a comment.</p>
       {% endif %}
 
-      {% for comment in comments %}
-      <div class="mb-6">
-        <div class="flex gap-3">
-          <span class="material-symbols-outlined text-2xl text-primary mt-1">account_circle</span>
-          <div class="flex-1">
-            <div class="flex items-center gap-2 mb-1">
-              <span class="text-sm font-bold text-on-surface">{{ comment.author.username }}</span>
-              <span class="text-xs text-on-surface-variant">{{ comment.created_at|timesince }} ago</span>
-            </div>
-            <p class="text-sm text-on-surface mb-2">{{ comment.body }}</p>
-            {% if request.user.is_authenticated %}
-            <button onclick="document.getElementById('reply-{{ comment.pk }}').classList.toggle('hidden')" class="text-xs text-secondary font-medium">Reply</button>
-            {% endif %}
-            {% if comment.author == request.user %}
-            <form method="POST" action="{% url 'blog:delete_comment' comment.pk %}" class="inline">
-              {% csrf_token %}
-              <button type="submit" class="text-xs text-error font-medium ml-3">Delete</button>
-            </form>
-            {% endif %}
-
-            <form method="POST" class="hidden mt-3" id="reply-{{ comment.pk }}">
-              {% csrf_token %}
-              <input type="hidden" name="parent_id" value="{{ comment.pk }}"/>
-              <textarea name="body" rows="2" placeholder="Write a reply..." class="w-full bg-surface-container-low border-none rounded-lg py-2 px-3 text-sm resize-none"></textarea>
-              <button type="submit" class="mt-2 bg-surface-container-high text-on-surface px-4 py-1.5 rounded-lg text-xs font-medium">Reply</button>
-            </form>
-
-            {% for reply in comment.replies.all %}
-            <div class="ml-8 mt-4 pl-4 border-l-2 border-outline-variant/20">
-              <div class="flex items-center gap-2 mb-1">
-                <span class="material-symbols-outlined text-lg text-primary">account_circle</span>
-                <span class="text-sm font-bold text-on-surface">{{ reply.author.username }}</span>
-                <span class="text-xs text-on-surface-variant">{{ reply.created_at|timesince }} ago</span>
-              </div>
-              <p class="text-sm text-on-surface">{{ reply.body }}</p>
-            </div>
-            {% endfor %}
-          </div>
-        </div>
+      <div id="comment-list">
+        {% for comment in comments %}
+        {% include 'blog/partials/comment_item.html' %}
+        {% empty %}
+        <p class="text-sm text-on-surface-variant" id="no-comments-msg">No comments yet. Be the first to share your thoughts!</p>
+        {% endfor %}
       </div>
-      {% empty %}
-      <p class="text-sm text-on-surface-variant">No comments yet. Be the first to share your thoughts!</p>
-      {% endfor %}
     </section>
 
     <!-- Related Posts -->

--- a/blog/templates/blog/partials/comment_item.html
+++ b/blog/templates/blog/partials/comment_item.html
@@ -1,0 +1,38 @@
+<div class="mb-6 comment-item" id="comment-{{ comment.pk }}">
+  <div class="flex gap-3">
+    <span class="material-symbols-outlined text-2xl text-primary mt-1">account_circle</span>
+    <div class="flex-1">
+      <div class="flex items-center gap-2 mb-1">
+        <span class="text-sm font-bold text-on-surface">{{ comment.author.username }}</span>
+        <span class="text-xs text-on-surface-variant">{{ comment.created_at|timesince }} ago</span>
+      </div>
+      <p class="text-sm text-on-surface mb-2">{{ comment.body }}</p>
+      {% if request.user.is_authenticated %}
+      <button onclick="document.getElementById('reply-{{ comment.pk }}').classList.toggle('hidden')" class="text-xs text-secondary font-medium">Reply</button>
+      {% endif %}
+      {% if comment.author == request.user %}
+      <button hx-post="{% url 'blog:delete_comment' comment.pk %}"
+              hx-target="#comment-{{ comment.pk }}"
+              hx-swap="outerHTML"
+              hx-confirm="Delete this comment?"
+              class="text-xs text-error font-medium ml-3">Delete</button>
+      {% endif %}
+
+      <form hx-post="{% url 'blog:comment_create' blog_post.slug %}"
+            hx-target="#replies-{{ comment.pk }}"
+            hx-swap="beforeend"
+            hx-on::after-request="if(event.detail.successful) this.reset()"
+            class="hidden mt-3" id="reply-{{ comment.pk }}">
+        <input type="hidden" name="parent_id" value="{{ comment.pk }}"/>
+        <textarea name="body" rows="2" placeholder="Write a reply..." class="w-full bg-surface-container-low border-none rounded-lg py-2 px-3 text-sm resize-none"></textarea>
+        <button type="submit" class="mt-2 bg-surface-container-high text-on-surface px-4 py-1.5 rounded-lg text-xs font-medium">Reply</button>
+      </form>
+
+      <div id="replies-{{ comment.pk }}">
+        {% for reply in comment.replies.all %}
+        {% include 'blog/partials/reply_item.html' %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/blog/templates/blog/partials/reply_item.html
+++ b/blog/templates/blog/partials/reply_item.html
@@ -1,0 +1,8 @@
+<div class="ml-8 mt-4 pl-4 border-l-2 border-outline-variant/20">
+  <div class="flex items-center gap-2 mb-1">
+    <span class="material-symbols-outlined text-lg text-primary">account_circle</span>
+    <span class="text-sm font-bold text-on-surface">{{ reply.author.username }}</span>
+    <span class="text-xs text-on-surface-variant">{{ reply.created_at|timesince }} ago</span>
+  </div>
+  <p class="text-sm text-on-surface">{{ reply.body }}</p>
+</div>

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -175,7 +175,8 @@ class LikeToggleViewTests(ModelTestMixin, TestCase):
 
 	def test_like_requires_auth(self):
 		response = self.client.post(reverse('blog:like', args=[self.post.slug]))
-		self.assertEqual(response.status_code, 401)
+		# @htmx_login_required redirects non-HTMX unauthenticated requests
+		self.assertEqual(response.status_code, 302)
 
 	def test_like_toggle(self):
 		self.client.login(email='test@nyasablog.com', password='testpass123')

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -342,10 +342,11 @@ class CommentSubmissionTests(ModelTestMixin, TestCase):
 	def test_comment_submission(self):
 		self.client.login(email='test@nyasablog.com', password='testpass123')
 		response = self.client.post(
-			reverse('blog:detail', args=[self.post.slug]),
-			{'body': 'Great article!'}
+			reverse('blog:comment_create', args=[self.post.slug]),
+			{'body': 'Great article!'},
+			HTTP_HX_REQUEST='true',
 		)
-		self.assertEqual(response.status_code, 302)
+		self.assertEqual(response.status_code, 200)
 		self.assertEqual(Comment.objects.count(), 1)
 		self.assertEqual(Comment.objects.first().body, 'Great article!')
 
@@ -353,10 +354,11 @@ class CommentSubmissionTests(ModelTestMixin, TestCase):
 		self.client.login(email='test@nyasablog.com', password='testpass123')
 		parent = Comment.objects.create(post=self.post, author=self.user, body='Parent comment')
 		response = self.client.post(
-			reverse('blog:detail', args=[self.post.slug]),
-			{'body': 'Reply to parent', 'parent_id': parent.pk}
+			reverse('blog:comment_create', args=[self.post.slug]),
+			{'body': 'Reply to parent', 'parent_id': parent.pk},
+			HTTP_HX_REQUEST='true',
 		)
-		self.assertEqual(response.status_code, 302)
+		self.assertEqual(response.status_code, 200)
 		reply = Comment.objects.filter(parent=parent).first()
 		self.assertIsNotNone(reply)
 		self.assertEqual(reply.body, 'Reply to parent')
@@ -371,7 +373,7 @@ class CommentSubmissionTests(ModelTestMixin, TestCase):
 	def test_delete_comment_denied_for_non_author(self):
 		self.client.login(email='other@nyasablog.com', password='testpass123')
 		comment = Comment.objects.create(post=self.post, author=self.user, body='Not yours')
-		response = self.client.get(reverse('blog:delete_comment', args=[comment.pk]))
+		response = self.client.post(reverse('blog:delete_comment', args=[comment.pk]))
 		self.assertEqual(response.status_code, 403)
 
 

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -5,6 +5,7 @@ from blog.views import (
 	edit_blog_view,
 	delete_blog_post,
 	delete_comment_view,
+	htmx_create_comment_view,
 	toggle_like_view,
 	toggle_bookmark_view,
 	bookmarks_view,
@@ -19,6 +20,7 @@ urlpatterns = [
 	path('<slug>/edit/', edit_blog_view, name="edit"),
 	path('<slug>/like/', toggle_like_view, name="like"),
 	path('<slug>/bookmark/', toggle_bookmark_view, name="bookmark"),
+	path('<slug>/comment/create/', htmx_create_comment_view, name="comment_create"),
 	path('delete/<pk>', delete_blog_post, name="delete"),
 	path('comment/delete/<int:pk>/', delete_comment_view, name="delete_comment"),
 ]

--- a/blog/views.py
+++ b/blog/views.py
@@ -36,22 +36,7 @@ def detail_blog_view(request, slug):
 	# Increment view count
 	BlogPost.objects.filter(pk=blog_post.pk).update(view_count=F('view_count') + 1)
 
-	# Handle comment submission
-	if request.method == 'POST' and request.user.is_authenticated:
-		comment_form = CommentForm(request.POST)
-		if comment_form.is_valid():
-			comment = comment_form.save(commit=False)
-			comment.post = blog_post
-			comment.author = request.user
-			parent_id = request.POST.get('parent_id')
-			if parent_id:
-				parent = get_object_or_404(Comment, pk=parent_id)
-				# Flatten to max 1 level: replies to replies become siblings
-				comment.parent = parent.parent or parent
-			comment.save()
-			return redirect('blog:detail', slug=slug)
-	else:
-		comment_form = CommentForm()
+	comment_form = CommentForm()
 
 	# Get comments (top-level only, replies via prefetch)
 	comments = blog_post.comments.filter(
@@ -126,15 +111,59 @@ def delete_blog_post(request, pk):
 	return render(request, 'blog/post_delete.html', context)
 
 
+@require_POST
 @login_required(login_url='must_authenticate')
 def delete_comment_view(request, pk):
 	comment = get_object_or_404(Comment, pk=pk)
 	if comment.author != request.user:
 		return HttpResponseForbidden('You are not the author of this comment.')
-	slug = comment.post.slug
-	if request.method == 'POST':
-		comment.delete()
-	return redirect('blog:detail', slug=slug)
+	post = comment.post
+	comment.delete()
+
+	if request.htmx:
+		new_count = post.comments.filter(is_active=True).count()
+		response = HttpResponse('')
+		trigger_toast(response, 'Comment deleted')
+		response.content += f'<span id="comment-count" hx-swap-oob="true">{new_count}</span>'.encode()
+		return response
+	return redirect('blog:detail', slug=post.slug)
+
+
+@require_POST
+@htmx_login_required
+def htmx_create_comment_view(request, slug):
+	post = get_object_or_404(BlogPost, slug=slug)
+	form = CommentForm(request.POST)
+	if form.is_valid():
+		comment = form.save(commit=False)
+		comment.post = post
+		comment.author = request.user
+		parent_id = request.POST.get('parent_id')
+		if parent_id:
+			parent = get_object_or_404(Comment, pk=parent_id, post=post)
+			comment.parent = parent.parent or parent
+		comment.save()
+
+		new_count = post.comments.filter(is_active=True).count()
+
+		if parent_id:
+			response = render(request, 'blog/partials/reply_item.html', {
+				'reply': comment,
+			})
+		else:
+			response = render(request, 'blog/partials/comment_item.html', {
+				'comment': comment,
+				'blog_post': post,
+			})
+		# OOB update for comment count
+		response.content += f'<span id="comment-count" hx-swap-oob="true">{new_count}</span>'.encode()
+		trigger_toast(response, 'Comment posted!')
+		return response
+
+	# Validation error
+	response = HttpResponse('Comment cannot be empty.', status=422)
+	trigger_toast(response, 'Comment cannot be empty.', 'error')
+	return response
 
 
 @require_POST

--- a/personal/templates/personal/home.html
+++ b/personal/templates/personal/home.html
@@ -195,9 +195,11 @@
       <div class="bg-[#002627] p-6 rounded-2xl text-white" id="newsletter-home">
         <h3 class="text-lg font-black mb-2">The Weekly Savanna</h3>
         <p class="text-sm text-white/70 mb-4">The best of Malawian stories, every Monday morning.</p>
-        <input id="newsletter-email-home" class="w-full bg-white/10 border-none rounded-lg py-2.5 px-4 text-sm text-white placeholder:text-white/50 mb-3" placeholder="Your email address" type="email"/>
-        <button onclick="submitNewsletter('newsletter-email-home', 'newsletter-msg-home')" class="w-full bg-tertiary-fixed-dim text-[#002627] py-2.5 rounded-lg text-sm font-bold hover:opacity-90 transition-opacity">Subscribe</button>
-        <p id="newsletter-msg-home" class="text-xs text-white/70 mt-2 hidden"></p>
+        <form hx-post="{% url 'subscribe' %}" hx-target="#newsletter-msg-home" hx-swap="innerHTML" hx-on::after-request="if(event.detail.successful) this.reset()">
+          <input name="email" class="w-full bg-white/10 border-none rounded-lg py-2.5 px-4 text-sm text-white placeholder:text-white/50 mb-3" placeholder="Your email address" type="email"/>
+          <button type="submit" class="w-full bg-tertiary-fixed-dim text-[#002627] py-2.5 rounded-lg text-sm font-bold hover:opacity-90 transition-opacity">Subscribe</button>
+        </form>
+        <p id="newsletter-msg-home" class="text-xs text-white/70 mt-2 empty:hidden"></p>
       </div>
 
     </div>

--- a/personal/templates/personal/search_results.html
+++ b/personal/templates/personal/search_results.html
@@ -133,13 +133,13 @@
       <section class="p-6 md:p-8 rounded-2xl bg-[#002627] text-white">
         <h4 class="text-xl font-bold mb-3">Never miss a story.</h4>
         <p class="text-white/70 text-sm mb-6">Weekly insights into Malawian culture and lifestyle delivered to your inbox.</p>
-        <div class="flex gap-2">
-          <input id="newsletter-email-search" class="flex-1 bg-white/10 border-none rounded-lg text-sm px-4 py-2 text-white placeholder:text-white/50 focus:ring-2 focus:ring-tertiary-fixed-dim" placeholder="Your email" type="email"/>
-          <button onclick="submitNewsletter('newsletter-email-search', 'newsletter-msg-search')" class="p-2 rounded-lg bg-tertiary-fixed-dim text-[#002627]">
+        <form hx-post="{% url 'subscribe' %}" hx-target="#newsletter-msg-search" hx-swap="innerHTML" hx-on::after-request="if(event.detail.successful) this.reset()" class="flex gap-2">
+          <input name="email" class="flex-1 bg-white/10 border-none rounded-lg text-sm px-4 py-2 text-white placeholder:text-white/50 focus:ring-2 focus:ring-tertiary-fixed-dim" placeholder="Your email" type="email"/>
+          <button type="submit" class="p-2 rounded-lg bg-tertiary-fixed-dim text-[#002627]">
             <span class="material-symbols-outlined">arrow_forward</span>
           </button>
-        </div>
-        <p id="newsletter-msg-search" class="text-xs text-white/70 mt-2 hidden"></p>
+        </form>
+        <p id="newsletter-msg-search" class="text-xs text-white/70 mt-2 empty:hidden"></p>
       </section>
 
     </div>

--- a/personal/views.py
+++ b/personal/views.py
@@ -143,11 +143,25 @@ def contact_screen_view(request):
 
 @require_POST
 def subscribe_view(request):
+	from django.core.validators import validate_email
+	from django.core.exceptions import ValidationError
+
 	email = request.POST.get('email', '').strip().lower()
 	if not email:
+		if request.htmx:
+			return HttpResponse('Please enter your email.', status=422)
 		return JsonResponse({'error': 'Email is required'}, status=400)
 
+	try:
+		validate_email(email)
+	except ValidationError:
+		if request.htmx:
+			return HttpResponse('Please enter a valid email.', status=422)
+		return JsonResponse({'error': 'Invalid email address'}, status=400)
+
 	subscriber, created = Subscriber.objects.get_or_create(email=email)
-	if created:
-		return JsonResponse({'success': True, 'message': 'Thanks for subscribing!'})
-	return JsonResponse({'success': True, 'message': 'You are already subscribed!'})
+	message = 'Thanks for subscribing!' if created else 'You are already subscribed!'
+
+	if request.htmx:
+		return HttpResponse(message)
+	return JsonResponse({'success': True, 'message': message})

--- a/templates/base.html
+++ b/templates/base.html
@@ -101,24 +101,6 @@ document.addEventListener('DOMContentLoaded', function() {
   if (icon) icon.textContent = document.documentElement.classList.contains('dark') ? 'light_mode' : 'dark_mode';
 });
 
-function submitNewsletter(inputId, msgId) {
-  var email = document.getElementById(inputId).value.trim();
-  var msg = document.getElementById(msgId);
-  if (!email) { msg.textContent = 'Please enter your email.'; msg.classList.remove('hidden'); return; }
-  fetch('{% url "subscribe" %}', {
-    method: 'POST',
-    headers: {'X-CSRFToken': '{{ csrf_token }}', 'Content-Type': 'application/x-www-form-urlencoded'},
-    credentials: 'same-origin',
-    body: 'email=' + encodeURIComponent(email)
-  })
-  .then(function(r) { return r.json(); })
-  .then(function(data) {
-    msg.textContent = data.message || data.error;
-    msg.classList.remove('hidden');
-    if (data.success) document.getElementById(inputId).value = '';
-  })
-  .catch(function() { msg.textContent = 'Something went wrong.'; msg.classList.remove('hidden'); });
-}
 </script>
 </body>
 </html>


### PR DESCRIPTION
[Replace newsletter JS with HTMX forms, add email validation](https://github.com/Kanyandula/BlogPost/commit/5a053eb36ecc66501d7b0abd0c7a60c7e36a0048) 

- Convert 3 newsletter subscribe forms to hx-post (home, search, profile)
- Modify subscribe_view to return HTML for HTMX, keep JSON for API
- Add email validation via validate_email before DB insert
- Return 422 on validation errors so HTMX doesn't trigger form reset
- Use empty:hidden on message elements to avoid dead space
- Remove submitNewsletter JS function from base.html (18 lines deleted)

[Fix test_like_requires_auth to expect 302 redirect](https://github.com/Kanyandula/BlogPost/commit/21833ac0c67bf7334157b7abd9c6d1ed0edd3fb2) 

The @htmx_login_required decorator redirects non-HTMX unauthenticated
requests (302) instead of returning JSON 401. Updated test assertion
to match the new behavior.
@Kanyandula

[Add HTMX comments: create, reply, delete without page reload](https://github.com/Kanyandula/BlogPost/commit/88a3dfe1d08cae9069742ba6332d604e1e8a2314) 

- Create htmx_create_comment_view with dedicated URL endpoint
- Extract comment_item.html and reply_item.html partials
- HTMX comment form with afterbegin swap and auto-reset
- HTMX reply forms targeting per-comment reply containers
- HTMX comment deletion with hx-confirm dialog
- OOB swap for comment count updates on create and delete
- Fix cross-post comment injection by filtering parent on post
- Remove comment POST handling from detail_blog_view
- Update tests for new comment_create endpoint