### PR TITLE
Add infinite scroll pagination for home and search pages

### DIFF
--- a/HTMX_REFACTOR.md
+++ b/HTMX_REFACTOR.md
@@ -11,10 +11,10 @@ Tracking document for migrating NyasaBlog from a traditional server-rendered Dja
 
 | Phase | Branch | Description | Status |
 |-------|--------|-------------|--------|
-| 0 | `htmx/phase-0-foundation` | Foundation + Toast + Auth Guard + CSRF | Pending |
-| 1 | `htmx/phase-1-likes-bookmarks` | Likes & Bookmarks (validates setup) | Pending |
-| 2 | `htmx/phase-2-newsletter` | Newsletter Subscribe | Pending |
-| 3 | `htmx/phase-3-comments` | Comments (submit, delete, OOB count) | Pending |
+| 0 | `htmx/phase-0-foundation` | Foundation + Toast + Auth Guard + CSRF | Done |
+| 1 | `htmx/phase-1-likes-bookmarks` | Likes & Bookmarks (validates setup) | Done |
+| 2 | `htmx/phase-2-newsletter` | Newsletter Subscribe | Done |
+| 3 | `htmx/phase-3-comments` | Comments (submit, delete, OOB count) | Done |
 | 4 | `htmx/phase-4-pagination` | Pagination / Infinite Scroll | Pending |
 | 5 | `htmx/phase-5-category-filter` | Category Filtering (explicit ?partial=) | Pending |
 | 6 | `htmx/phase-6-live-search` | Live Search (header dropdown + page) | Pending |

--- a/personal/templates/personal/home.html
+++ b/personal/templates/personal/home.html
@@ -92,60 +92,8 @@
 
     {% if blog_posts %}
     <div id="posts-grid" class="grid grid-cols-1 md:grid-cols-2 gap-10">
-      {% for post in blog_posts %}
-      <article class="flex flex-col group">
-        <a href="{% url 'blog:detail' post.slug %}">
-          <div class="aspect-video mb-6 overflow-hidden rounded-lg bg-surface-container-low">
-            {% if post.image %}
-            <img alt="{{ post.title }}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" src="{{ post.image.url }}"/>
-            {% else %}
-            <div class="w-full h-full bg-surface-container-high flex items-center justify-center">
-              <span class="material-symbols-outlined text-4xl text-outline-variant">article</span>
-            </div>
-            {% endif %}
-          </div>
-        </a>
-        <div class="flex items-center gap-2 mb-3">
-          {% if post.category %}
-          <span class="text-[10px] font-black uppercase tracking-tighter text-secondary">{{ post.category.name }}</span>
-          <span class="w-1 h-1 rounded-full bg-outline-variant"></span>
-          {% endif %}
-          <span class="text-[10px] text-outline">{{ post.date_published|date:"M d, Y" }}</span>
-        </div>
-        <a href="{% url 'blog:detail' post.slug %}">
-          <h3 class="text-xl font-bold text-primary mb-3 leading-snug group-hover:text-secondary transition-colors line-clamp-2">{{ post.title }}</h3>
-        </a>
-        <p class="text-on-surface-variant text-sm mb-6 line-clamp-2">{{ post.body|striptags|truncatechars:140 }}</p>
-        <div class="flex items-center justify-between mt-auto text-xs">
-          <a href="{% url 'author_profile' post.author.username %}" class="font-bold text-primary hover:text-secondary">{{ post.author.username }}</a>
-          <div class="flex items-center gap-3 text-on-surface-variant">
-            <span>{{ post.reading_time }} min</span>
-            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-sm">favorite</span>{{ post.like_count }}</span>
-            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-sm">chat</span>{{ post.comment_count }}</span>
-          </div>
-        </div>
-      </article>
-      {% endfor %}
+      {% include 'personal/partials/post_grid.html' %}
     </div>
-
-    <!-- Pagination -->
-    {% if blog_posts.has_other_pages %}
-    <div class="flex justify-center gap-2 mt-12">
-      {% if blog_posts.has_previous %}
-      <a href="?page={{ blog_posts.previous_page_number }}{% if query %}&q={{ query }}{% endif %}{% if active_category %}&category={{ active_category }}{% endif %}"
-         class="px-4 py-2 rounded-lg bg-surface-container-high text-on-surface text-sm hover:bg-surface-container-highest transition-colors">
-        <span class="material-symbols-outlined text-sm align-middle">chevron_left</span> Previous
-      </a>
-      {% endif %}
-      <span class="px-4 py-2 text-sm text-on-surface-variant">Page {{ blog_posts.number }} of {{ blog_posts.paginator.num_pages }}</span>
-      {% if blog_posts.has_next %}
-      <a href="?page={{ blog_posts.next_page_number }}{% if query %}&q={{ query }}{% endif %}{% if active_category %}&category={{ active_category }}{% endif %}"
-         class="px-4 py-2 rounded-lg bg-surface-container-high text-on-surface text-sm hover:bg-surface-container-highest transition-colors">
-        Next <span class="material-symbols-outlined text-sm align-middle">chevron_right</span>
-      </a>
-      {% endif %}
-    </div>
-    {% endif %}
 
     {% else %}
     <!-- Empty state -->

--- a/personal/templates/personal/partials/post_grid.html
+++ b/personal/templates/personal/partials/post_grid.html
@@ -1,0 +1,45 @@
+{% load static %}
+{% for post in blog_posts %}
+<article class="flex flex-col group">
+  <a href="{% url 'blog:detail' post.slug %}">
+    <div class="aspect-video mb-6 overflow-hidden rounded-lg bg-surface-container-low">
+      {% if post.image %}
+      <img alt="{{ post.title }}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" src="{{ post.image.url }}"/>
+      {% else %}
+      <div class="w-full h-full bg-surface-container-high flex items-center justify-center">
+        <span class="material-symbols-outlined text-4xl text-outline-variant">article</span>
+      </div>
+      {% endif %}
+    </div>
+  </a>
+  <div class="flex items-center gap-2 mb-3">
+    {% if post.category %}
+    <span class="text-[10px] font-black uppercase tracking-tighter text-secondary">{{ post.category.name }}</span>
+    <span class="w-1 h-1 rounded-full bg-outline-variant"></span>
+    {% endif %}
+    <span class="text-[10px] text-outline">{{ post.date_published|date:"M d, Y" }}</span>
+  </div>
+  <a href="{% url 'blog:detail' post.slug %}">
+    <h3 class="text-xl font-bold text-primary mb-3 leading-snug group-hover:text-secondary transition-colors line-clamp-2">{{ post.title }}</h3>
+  </a>
+  <p class="text-on-surface-variant text-sm mb-6 line-clamp-2">{{ post.body|striptags|truncatechars:140 }}</p>
+  <div class="flex items-center justify-between mt-auto text-xs">
+    <a href="{% url 'author_profile' post.author.username %}" class="font-bold text-primary hover:text-secondary">{{ post.author.username }}</a>
+    <div class="flex items-center gap-3 text-on-surface-variant">
+      <span>{{ post.reading_time }} min</span>
+      <span class="flex items-center gap-1"><span class="material-symbols-outlined text-sm">favorite</span>{{ post.like_count }}</span>
+      <span class="flex items-center gap-1"><span class="material-symbols-outlined text-sm">chat</span>{{ post.comment_count }}</span>
+    </div>
+  </div>
+</article>
+{% endfor %}
+
+{% if blog_posts.has_next %}
+<div hx-get="?page={{ blog_posts.next_page_number }}{% if query %}&q={{ query|urlencode }}{% endif %}{% if active_category %}&category={{ active_category|urlencode }}{% endif %}&partial=post_grid"
+     hx-trigger="revealed"
+     hx-swap="outerHTML"
+     class="col-span-full flex justify-center py-8">
+  <span class="htmx-indicator material-symbols-outlined animate-spin text-primary">progress_activity</span>
+  <span class="text-sm text-on-surface-variant">Loading more stories...</span>
+</div>
+{% endif %}

--- a/personal/templates/personal/partials/search_results_list.html
+++ b/personal/templates/personal/partials/search_results_list.html
@@ -1,0 +1,42 @@
+{% for post in blog_posts %}
+<article class="flex flex-col md:flex-row gap-6 md:gap-8 group">
+  <a href="{% url 'blog:detail' post.slug %}" class="w-full md:w-64 shrink-0">
+    <div class="aspect-[16/10] rounded-xl overflow-hidden bg-surface-container-low">
+      {% if post.image %}
+      <img alt="{{ post.title }}" class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" src="{{ post.image.url }}"/>
+      {% else %}
+      <div class="w-full h-full flex items-center justify-center">
+        <span class="material-symbols-outlined text-4xl text-outline-variant">article</span>
+      </div>
+      {% endif %}
+    </div>
+  </a>
+  <div class="flex flex-col justify-center">
+    <div class="flex items-center gap-3 mb-3">
+      {% if post.category %}
+      <span class="text-[10px] tracking-widest font-bold text-secondary uppercase">{{ post.category.name }}</span>
+      <span class="w-1 h-1 rounded-full bg-outline-variant"></span>
+      {% endif %}
+      <span class="text-xs text-on-surface-variant">{{ post.date_published|date:"M d, Y" }}</span>
+    </div>
+    <a href="{% url 'blog:detail' post.slug %}">
+      <h3 class="text-xl md:text-2xl font-bold text-primary mb-3 leading-tight group-hover:text-secondary transition-colors">{{ post.title }}</h3>
+    </a>
+    <p class="text-on-surface-variant leading-relaxed mb-4 line-clamp-2 text-sm">{{ post.body|striptags|truncatechars:180 }}</p>
+    <div class="flex items-center gap-3">
+      <span class="material-symbols-outlined text-base text-outline">account_circle</span>
+      <a href="{% url 'author_profile' post.author.username %}" class="text-xs font-semibold text-on-surface hover:text-primary">{{ post.author.username }}</a>
+      <span class="text-xs text-outline">· {{ post.reading_time }} min read</span>
+    </div>
+  </div>
+</article>
+{% endfor %}
+
+{% if blog_posts.has_next %}
+<div hx-get="?q={{ query|urlencode }}{% if active_category %}&category={{ active_category|urlencode }}{% endif %}&page={{ blog_posts.next_page_number }}&partial=search_list"
+     hx-trigger="revealed"
+     hx-swap="outerHTML"
+     class="py-12 flex justify-center">
+  <span class="text-sm text-on-surface-variant">Loading more stories...</span>
+</div>
+{% endif %}

--- a/personal/templates/personal/search_results.html
+++ b/personal/templates/personal/search_results.html
@@ -36,51 +36,9 @@
   <!-- Search Results -->
   <section class="lg:col-span-8 flex flex-col gap-12">
     {% if blog_posts %}
-      {% for post in blog_posts %}
-      <article class="flex flex-col md:flex-row gap-6 md:gap-8 group">
-        <a href="{% url 'blog:detail' post.slug %}" class="w-full md:w-64 shrink-0">
-          <div class="aspect-[16/10] rounded-xl overflow-hidden bg-surface-container-low">
-            {% if post.image %}
-            <img alt="{{ post.title }}" class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" src="{{ post.image.url }}"/>
-            {% else %}
-            <div class="w-full h-full flex items-center justify-center">
-              <span class="material-symbols-outlined text-4xl text-outline-variant">article</span>
-            </div>
-            {% endif %}
-          </div>
-        </a>
-        <div class="flex flex-col justify-center">
-          <div class="flex items-center gap-3 mb-3">
-            {% if post.category %}
-            <span class="text-[10px] tracking-widest font-bold text-secondary uppercase">{{ post.category.name }}</span>
-            <span class="w-1 h-1 rounded-full bg-outline-variant"></span>
-            {% endif %}
-            <span class="text-xs text-on-surface-variant">{{ post.date_published|date:"M d, Y" }}</span>
-          </div>
-          <a href="{% url 'blog:detail' post.slug %}">
-            <h3 class="text-xl md:text-2xl font-bold text-primary mb-3 leading-tight group-hover:text-secondary transition-colors">{{ post.title }}</h3>
-          </a>
-          <p class="text-on-surface-variant leading-relaxed mb-4 line-clamp-2 text-sm">{{ post.body|striptags|truncatechars:180 }}</p>
-          <div class="flex items-center gap-3">
-            <span class="material-symbols-outlined text-base text-outline">account_circle</span>
-            <a href="{% url 'author_profile' post.author.username %}" class="text-xs font-semibold text-on-surface hover:text-primary">{{ post.author.username }}</a>
-            <span class="text-xs text-outline">· {{ post.reading_time }} min read</span>
-          </div>
-        </div>
-      </article>
-      {% endfor %}
-
-      <!-- Pagination -->
-      {% if blog_posts.has_other_pages %}
-      <div class="py-12 flex justify-center">
-        {% if blog_posts.has_next %}
-        <a href="?q={{ query }}{% if active_category %}&category={{ active_category }}{% endif %}&page={{ blog_posts.next_page_number }}"
-           class="px-8 py-3 rounded-full border border-outline-variant text-primary font-bold hover:bg-surface-container-low transition-all">
-          Load More Stories
-        </a>
-        {% endif %}
+      <div id="search-results-list">
+        {% include 'personal/partials/search_results_list.html' %}
       </div>
-      {% endif %}
 
     {% else %}
       <!-- Empty State -->

--- a/personal/views.py
+++ b/personal/views.py
@@ -44,21 +44,6 @@ def home_screen_view(request):
 			BlogPost.objects.filter(status='published')
 		).order_by('-date_updated')
 
-	# Featured posts
-	featured_posts = BlogPost.objects.filter(
-		is_featured=True, status='published'
-	).select_related('author').order_by('-date_published')[:3]
-
-	# Trending posts
-	trending_posts = BlogPost.objects.filter(
-		status='published'
-	).annotate(
-		like_count=Count('likes')
-	).order_by('-view_count', '-like_count')[:5]
-
-	# Categories for filter pills
-	categories = Category.objects.all()
-
 	# Pagination
 	page = request.GET.get('page', 1)
 	blog_posts_paginator = Paginator(blog_posts, BLOG_POSTS_PER_PAGE)
@@ -71,11 +56,22 @@ def home_screen_view(request):
 		blog_posts = blog_posts_paginator.page(blog_posts_paginator.num_pages)
 
 	context['blog_posts'] = blog_posts
-	context['featured_posts'] = featured_posts
-	context['trending_posts'] = trending_posts
-	context['categories'] = categories
 	context['active_category'] = category_slug
 
+	# HTMX partial — skip sidebar queries
+	if request.htmx and request.GET.get('partial') == 'post_grid':
+		return render(request, 'personal/partials/post_grid.html', context)
+
+	# Full page — compute sidebar data
+	context['featured_posts'] = BlogPost.objects.filter(
+		is_featured=True, status='published'
+	).select_related('author').order_by('-date_published')[:3]
+	context['trending_posts'] = BlogPost.objects.filter(
+		status='published'
+	).annotate(
+		like_count=Count('likes')
+	).order_by('-view_count', '-like_count')[:5]
+	context['categories'] = Category.objects.all()
 	return render(request, "personal/home.html", context)
 
 
@@ -109,10 +105,15 @@ def search_view(request):
 		blog_posts = paginator.page(paginator.num_pages)
 
 	context['blog_posts'] = blog_posts
-	context['categories'] = Category.objects.all()
 	context['active_category'] = category_slug
-	context['tags'] = Tag.objects.all()[:20]
 
+	# HTMX partial — skip sidebar queries
+	if request.htmx and request.GET.get('partial') == 'search_list':
+		return render(request, 'personal/partials/search_results_list.html', context)
+
+	# Full page — compute sidebar data
+	context['categories'] = Category.objects.all()
+	context['tags'] = Tag.objects.all()[:20]
 	return render(request, 'personal/search_results.html', context)
 
 


### PR DESCRIPTION
- Extract post_grid.html partial (home page grid cards)
- Extract search_results_list.html partial (search page list cards)
- Add hx-trigger="revealed" sentinel for automatic infinite scroll
- Skip sidebar DB queries (featured, trending, categories, tags) on HTMX partial requests for better performance
- URL-encode query params in infinite scroll sentinel URLs
- Remove traditional previous/next pagination blocks
- Update HTMX_REFACTOR.md status for completed phases