### PR TITLE
Security: post-audit hardening (auth, HTTPS, host injection, XSS sanitizer)

### DIFF
--- a/account/api/views.py
+++ b/account/api/views.py
@@ -164,12 +164,14 @@ class ObtainAuthTokenView(APIView):
 @permission_classes([])
 @authentication_classes([])
 def does_account_exist_view(request):
-
+	# NOTE: This endpoint is a user-enumeration oracle (returns the email when it
+	# exists, sentinel string otherwise). Behavior preserved for the v1 Android
+	# password-reset client; remove together with that client when v2 lands.
 	if request.method == 'GET':
-		email = request.GET['email'].lower()
+		email = (request.GET.get('email') or '').lower()
 		data = {}
 		try:
-			account = Account.objects.get(email=email)
+			Account.objects.get(email=email)
 			data['response'] = email
 		except Account.DoesNotExist:
 			data['response'] = "Account does not exist"

--- a/account/decorators.py
+++ b/account/decorators.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from urllib.parse import urlencode
+
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+def email_verified_required(view_func):
+    """Web-view decorator that gates write actions on email verification.
+
+    Apply *after* @login_required (closer to the function). Anonymous users are
+    redirected to login by login_required first; authenticated-but-unverified
+    users land on verification_sent so they can request a fresh link.
+    """
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if request.user.is_authenticated and not request.user.email_verified:
+            target = f"{reverse('verification_sent')}?{urlencode({'email': request.user.email})}"
+            return redirect(target)
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped

--- a/account/emails.py
+++ b/account/emails.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes
@@ -6,12 +7,18 @@ from django.utils.http import urlsafe_base64_encode
 from account.tokens import email_verification_token
 
 
-def send_verification_email(user, request):
-    """Send the email-verification link to `user`. Trusts `request.get_host()` for the domain."""
+def send_verification_email(user, request=None):
+    """Send the email-verification link to `user`.
+
+    Domain and protocol are pulled from settings (SITE_DOMAIN, SITE_PROTOCOL) rather
+    than the inbound request, so a forged Host header cannot redirect the link to
+    an attacker-controlled domain. `request` is accepted but unused; kept for
+    backward compatibility with existing callers.
+    """
     context = {
         'user': user,
-        'domain': request.get_host(),
-        'protocol': 'https' if request.is_secure() else 'http',
+        'domain': settings.SITE_DOMAIN,
+        'protocol': settings.SITE_PROTOCOL,
         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
         'token': email_verification_token.make_token(user),
     }

--- a/account/tests.py
+++ b/account/tests.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.core.management import call_command
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
-from django.test import TestCase, TransactionTestCase, RequestFactory, Client
+from django.test import TestCase, TransactionTestCase, RequestFactory, Client, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
@@ -464,16 +464,26 @@ class SendVerificationEmailTests(TestCase):
         )
         self.factory = RequestFactory()
 
+    @override_settings(SITE_DOMAIN='nyasablog.com', SITE_PROTOCOL='https')
     def test_send_verification_email_appends_to_outbox(self):
         from account.emails import send_verification_email
-        request = self.factory.get('/')
-        request.META['HTTP_HOST'] = 'nyasablog.com'
-        send_verification_email(self.user, request)
+        send_verification_email(self.user)
         self.assertEqual(len(mail.outbox), 1)
         msg = mail.outbox[0]
         self.assertEqual(msg.to, [self.user.email])
         self.assertIn('confirm-email', msg.body)
-        self.assertIn('nyasablog.com', msg.body)
+        self.assertIn('https://nyasablog.com/confirm-email/', msg.body)
+
+    @override_settings(SITE_DOMAIN='nyasablog.com', SITE_PROTOCOL='https')
+    def test_send_verification_email_ignores_request_host_header(self):
+        """Forged Host header must not influence the verification link."""
+        from account.emails import send_verification_email
+        request = self.factory.get('/')
+        request.META['HTTP_HOST'] = 'attacker.example'
+        send_verification_email(self.user, request)
+        msg = mail.outbox[0]
+        self.assertNotIn('attacker.example', msg.body)
+        self.assertIn('https://nyasablog.com/', msg.body)
 
 
 class ConfirmEmailViewTests(TestCase):
@@ -1111,3 +1121,42 @@ class AccountWriteEndpointGatingTests(APITestCase):
             'email': 'un@x.com', 'username': 'newun',
         })
         self.assertEqual(response.status_code, 403)
+
+
+class HTMLViewEmailVerifiedGatingTests(TestCase):
+    """Confirms web write views redirect unverified users to verification_sent."""
+
+    def setUp(self):
+        self.unverified = Account.objects.create_user(
+            email='unv@x.com', username='unvuser', password='testpass123'  # pragma: allowlist secret
+        )  # is_active=True, email_verified=False — mirrors API v1 register output
+        self.verified = Account.objects.create_user(
+            email='ver@x.com', username='veruser', password='testpass123'  # pragma: allowlist secret
+        )
+        self.verified.email_verified = True
+        self.verified.save()
+
+    def _login(self, user):
+        self.client.force_login(user, backend='account.backends.CaseInsensitiveModelBackend')
+
+    def test_unverified_redirected_from_create_blog(self):
+        self._login(self.unverified)
+        response = self.client.get(reverse('blog:create'))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('verification', response['Location'])
+
+    def test_unverified_redirected_from_account_view(self):
+        self._login(self.unverified)
+        response = self.client.get(reverse('account'))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('verification', response['Location'])
+
+    def test_verified_can_access_create_blog(self):
+        self._login(self.verified)
+        response = self.client.get(reverse('blog:create'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_verified_can_access_account_view(self):
+        self._login(self.verified)
+        response = self.client.get(reverse('account'))
+        self.assertEqual(response.status_code, 200)

--- a/account/views.py
+++ b/account/views.py
@@ -125,10 +125,10 @@ def login_view(request):
 			email = request.POST['email']
 			password = request.POST['password']
 			user = authenticate(email=email, password=password)
-			# AUTHENTICATION_BACKENDS lists AllowAllUsersModelBackend first, which lets
-			# inactive users through authenticate(). The email_verified check below is
-			# therefore the *sole* gate for the web login flow — don't drop it without
-			# also re-evaluating the backend config.
+			# CaseInsensitiveModelBackend (the only configured backend) inherits
+			# user_can_authenticate() from ModelBackend, so authenticate() already
+			# returns None for is_active=False accounts. The email_verified check is
+			# the second-stage gate for active-but-unverified accounts.
 			if user and user.email_verified:
 				login(request, user)
 				if getattr(request, 'htmx', False):
@@ -153,6 +153,12 @@ def account_view(request):
 
 	if not request.user.is_authenticated:
 			return redirect("login")
+
+	# Unverified users land on verification_sent — they shouldn't be able to
+	# edit profile/avatar/social links until they prove the email is theirs.
+	if not request.user.email_verified:
+		target = f"{reverse('verification_sent')}?{urlencode({'email': request.user.email})}"
+		return redirect(target)
 
 	context = {}
 	profile = request.user.profile

--- a/blog/templatetags/sanitize.py
+++ b/blog/templatetags/sanitize.py
@@ -9,14 +9,16 @@ ALLOWED_TAGS = {
     "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "li",
     "ol", "p", "pre", "strong", "sub", "sup", "table", "tbody",
     "td", "th", "thead", "tr", "u", "ul", "figure", "figcaption",
-    "div", "span", "iframe",
+    "div", "span",
 }
 
+# `style` is intentionally not allowed — inline CSS enables overlay/exfiltration
+# attacks (full-viewport positioned elements, url() leaks). Tailwind classes are
+# enough for CKEditor-generated markup.
 ALLOWED_ATTRIBUTES = {
-    "*": {"class", "style"},
+    "*": {"class"},
     "a": {"href", "title", "target"},
     "img": {"src", "alt", "width", "height", "loading"},
-    "iframe": {"src", "width", "height", "frameborder", "allowfullscreen"},
     "td": {"colspan", "rowspan"},
     "th": {"colspan", "rowspan"},
 }

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -11,9 +11,13 @@ class ModelTestMixin:
 		self.user = Account.objects.create_user(
 			email='test@nyasablog.com', username='testuser', password='testpass123'
 		)
+		self.user.email_verified = True
+		self.user.save()
 		self.user2 = Account.objects.create_user(
 			email='other@nyasablog.com', username='otheruser', password='testpass123'
 		)
+		self.user2.email_verified = True
+		self.user2.save()
 		self.category, _ = Category.objects.get_or_create(name='Culture', slug='culture', defaults={'description': 'Test'})
 		self.tag, _ = Tag.objects.get_or_create(name='Malawi', slug='malawi')
 		self.post = BlogPost.objects.create(
@@ -383,3 +387,31 @@ class BookmarkTogglePostMethodTests(ModelTestMixin, TestCase):
 		self.client.login(email='test@nyasablog.com', password='testpass123')
 		response = self.client.get(reverse('blog:bookmark', args=[self.post.slug]))
 		self.assertEqual(response.status_code, 405)
+
+
+class SanitizeHtmlFilterTests(TestCase):
+	"""nh3 filter must strip iframe tags and inline style attributes."""
+
+	def _clean(self, raw):
+		from blog.templatetags.sanitize import sanitize_html
+		return str(sanitize_html(raw))
+
+	def test_iframe_is_stripped(self):
+		out = self._clean('<p>Hi</p><iframe src="https://attacker.com/phish"></iframe>')
+		self.assertNotIn('<iframe', out)
+		self.assertNotIn('attacker.com', out)
+
+	def test_inline_style_is_stripped(self):
+		raw = '<div style="position:absolute;top:0;left:0;width:100%;height:100%;background:red">x</div>'
+		out = self._clean(raw)
+		self.assertNotIn('style=', out)
+		self.assertIn('<div', out)
+
+	def test_safe_tags_preserved(self):
+		out = self._clean('<p class="lead"><strong>hi</strong> <a href="https://x">link</a></p>')
+		self.assertIn('<strong>hi</strong>', out)
+		self.assertIn('href="https://x"', out)
+
+	def test_javascript_url_blocked(self):
+		out = self._clean('<a href="javascript:alert(1)">click</a>')
+		self.assertNotIn('javascript:', out)

--- a/blog/views.py
+++ b/blog/views.py
@@ -4,12 +4,14 @@ from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.views.decorators.http import require_POST
 from django.contrib.auth.decorators import login_required
 
+from account.decorators import email_verified_required
 from blog.models import BlogPost, Category, Comment, Like, Bookmark
 from blog.forms import CreateBlogPostForm, UpdateBlogPostForm, CommentForm
 from blog.utils import htmx_login_required, trigger_toast
 
 
 @login_required(login_url='must_authenticate')
+@email_verified_required
 def create_blog_view(request):
 	context = {}
 
@@ -63,6 +65,7 @@ def detail_blog_view(request, slug):
 
 
 @login_required(login_url='must_authenticate')
+@email_verified_required
 def edit_blog_view(request, slug):
 	context = {}
 
@@ -100,6 +103,7 @@ def get_blog_queryset(query=None):
 
 
 @login_required(login_url='must_authenticate')
+@email_verified_required
 def delete_blog_post(request, pk):
 	post = get_object_or_404(BlogPost, id=pk)
 	if post.author != request.user:
@@ -113,6 +117,7 @@ def delete_blog_post(request, pk):
 
 @require_POST
 @login_required(login_url='must_authenticate')
+@email_verified_required
 def delete_comment_view(request, pk):
 	comment = get_object_or_404(Comment, pk=pk)
 	if comment.author != request.user:

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = config('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', default=False, cast=bool)
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '104.248.204.211', 'www.nyasablog.com', 'nyasablog.com']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'www.nyasablog.com', 'nyasablog.com']
 
 
 # Application definition
@@ -56,10 +56,9 @@ INSTALLED_APPS = [
 
 AUTH_USER_MODEL = 'account.Account'
 
-AUTHENTICATION_BACKENDS = ( 
-    'django.contrib.auth.backends.AllowAllUsersModelBackend', 
+AUTHENTICATION_BACKENDS = (
     'account.backends.CaseInsensitiveModelBackend',
-    )
+)
     
     
 REST_FRAMEWORK = {
@@ -193,6 +192,23 @@ else:
     # worker timeout fires. Without this, hanging SMTP connects → SIGABRT →
     # 500 with no chance to release the resend cooldown cache.
     EMAIL_TIMEOUT = 10
+
+    # HTTPS / cookie security. Nginx terminates TLS and forwards X-Forwarded-Proto,
+    # so request.is_secure() and the SSL redirect both rely on SECURE_PROXY_SSL_HEADER.
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = 'DENY'
+
+# Verification-email link domain. Sourced from settings.ini, not request.get_host(),
+# so a forged Host header cannot redirect verification links to an attacker domain.
+SITE_DOMAIN = config('SITE_DOMAIN', default='localhost:8000')
+SITE_PROTOCOL = config('SITE_PROTOCOL', default='http')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -17,3 +17,7 @@ DB_USER=nyasablog_user
 DB_PASSWORD=
 DB_HOST=localhost
 DB_PORT=5432
+# Domain used in transactional email links. Must NOT include a scheme.
+# Production: nyasablog.com   Local dev: localhost:8000
+SITE_DOMAIN=localhost:8000
+SITE_PROTOCOL=http


### PR DESCRIPTION
## Summary

Fixes from the post-PR-#34 security audit. Five focused commits, 212/212 tests passing locally.

| # | Fix |
|---|-----|
| 1 | Drop `AllowAllUsersModelBackend` — `CaseInsensitiveModelBackend` already enforces `is_active` via `user_can_authenticate()`. Drop raw Droplet IP from `ALLOWED_HOSTS`. Add prod-only HTTPS settings: `SECURE_SSL_REDIRECT`, `SECURE_PROXY_SSL_HEADER`, secure cookies, HSTS (1y, subdomains, preload), nosniff, `X-Frame-Options=DENY`. |
| 2 | Verification email domain now reads `SITE_DOMAIN`/`SITE_PROTOCOL` from `settings.ini` instead of `request.get_host()` — closes a host-header injection that could redirect verification links to an attacker domain. |
| 3 | New `email_verified_required` decorator applied to HTML write views (`create_blog`, `edit_blog`, `delete_blog_post`, `delete_comment`, `account_view`). PR #34 only gated the API surface; the HTML write paths were unprotected. |
| 4 | Tighten `sanitize_html` filter: drop `<iframe>` allowlist entry and the global `style` attribute. Inline `style` enables overlay/exfiltration attacks; Tailwind classes are sufficient for CKEditor output. |
| 5 | `does_account_exist` returned HTTP 500 on missing `?email=` param. Use `.get()` with default. (NOTE comment flags the user-enumeration oracle for a future coordinated v1-deprecation PR.) |

## Out of scope (need separate decisions)

- **API v1 email-verification bypass** — existing tests assert this as intentional Android-WebView back-compat. Fixing requires v1 deprecation.
- **Token disclosure on `api_confirm_email` already-verified idempotency path** — also asserted by existing tests.
- **Login/register/resend rate limiting** — needs DRF throttle config + a shared cache backend (Redis or Memcached) so per-worker LocMemCache doesn't defeat the cooldown.
- **`does_account_exist` enumeration oracle** — v1 password-reset client uses the response value; coordinated client change required.
- **Missing `password_reset_confirm.html`** — UX, not security.

## Required deploy steps

1. Add to production `settings.ini`:
   ```
   SITE_DOMAIN=nyasablog.com
   SITE_PROTOCOL=https
   ```
   Without these, verification emails default to `http://localhost:8000`.

2. Verify Nginx forwards `X-Forwarded-Proto: https` to Gunicorn. Without it, `SECURE_SSL_REDIRECT=True` causes an infinite redirect loop.

## Test plan
- [x] `python manage.py test` passes (212/212 locally on Python 3.13)
- [ ] On staging: register via web flow → verification email link uses `https://nyasablog.com/...`
- [ ] On staging: register via web flow → log in attempt while unverified → blocked
- [ ] On staging: log in as unverified user → attempt `/blog/create/` → redirected to verification_sent
- [ ] On staging: blog post body containing `<iframe>` or inline `style` is rendered with both stripped
- [ ] On staging: confirm Nginx forwards `X-Forwarded-Proto`; no redirect loops
- [ ] On staging: `GET /api/account/check_if_account_exists/` (no `?email=`) returns 200 not 500