### PR TITLE
Refactor: structured AboutPage singleton (fixes ugly /about after edits)

### DIFF
--- a/personal/admin.py
+++ b/personal/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from personal.models import Page, Subscriber
+from personal.models import AboutPage, Subscriber
 
 
 @admin.register(Subscriber)
@@ -19,10 +19,23 @@ class SubscriberAdmin(admin.ModelAdmin):
 		return response
 
 
-@admin.register(Page)
-class PageAdmin(admin.ModelAdmin):
-	list_display = ('slug', 'title', 'is_published', 'updated_at')
-	list_filter = ('is_published',)
-	search_fields = ('slug', 'title')
+@admin.register(AboutPage)
+class AboutPageAdmin(admin.ModelAdmin):
+	"""Singleton admin: hide the changelist 'Add' button so only one row exists."""
+
 	readonly_fields = ('updated_at',)
-	fields = ('slug', 'title', 'is_published', 'body', 'updated_at')
+	fieldsets = (
+		(None, {'fields': ('is_published',)}),
+		('Intro', {'fields': ('intro',)}),
+		('Mission section', {'fields': ('mission_title', 'mission_body')}),
+		('Categories section', {'fields': ('categories_heading', 'categories')}),
+		('Founder section', {'fields': ('founder_title', 'founder_body')}),
+		('Metadata', {'fields': ('updated_at',)}),
+	)
+
+	def has_add_permission(self, request):
+		# Allow add only if no instance exists yet.
+		return not AboutPage.objects.exists()
+
+	def has_delete_permission(self, request, obj=None):
+		return False

--- a/personal/migrations/0006_replace_page_with_about_page.py
+++ b/personal/migrations/0006_replace_page_with_about_page.py
@@ -1,0 +1,78 @@
+from django.db import migrations, models
+
+
+DEFAULT_INTRO = (
+	"NyasaBlog is a digital platform dedicated to promoting positive content "
+	"created by Malawian content creators and influencers. Our aim is to be "
+	"the most trusted source for Malawian content in the areas of Culture, "
+	"Entertainment, Entrepreneurship, and many more."
+)
+
+DEFAULT_MISSION_BODY = (
+	"To amplify Malawian voices and showcase the best of Malawian creativity, "
+	"innovation, and culture to the world."
+)
+
+DEFAULT_CATEGORIES = (
+	"Culture, Entertainment, Entrepreneurship, Tourism, Technology, "
+	"Sports, Lifestyle, Education, Health, Opinion"
+)
+
+DEFAULT_FOUNDER_BODY = (
+	"NyasaBlog was created by Ephraim Kanyandula, a Malawian national, with "
+	"the vision of building a platform that amplifies Malawian voices and "
+	"showcases the best of Malawian creativity and innovation."
+)
+
+
+def seed_about(apps, schema_editor):
+	AboutPage = apps.get_model('personal', 'AboutPage')
+	if not AboutPage.objects.exists():
+		AboutPage.objects.create(
+			intro=DEFAULT_INTRO,
+			mission_title='Our Mission',
+			mission_body=DEFAULT_MISSION_BODY,
+			categories_heading='Categories We Cover',
+			categories=DEFAULT_CATEGORIES,
+			founder_title='Founded by Ephraim Kanyandula',
+			founder_body=DEFAULT_FOUNDER_BODY,
+			is_published=True,
+		)
+
+
+def unseed_about(apps, schema_editor):
+	AboutPage = apps.get_model('personal', 'AboutPage')
+	AboutPage.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('personal', '0005_seed_about_page'),
+	]
+
+	operations = [
+		migrations.CreateModel(
+			name='AboutPage',
+			fields=[
+				('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+				('intro', models.TextField(help_text='The opening paragraph beneath the page title.')),
+				('mission_title', models.CharField(default='Our Mission', max_length=80)),
+				('mission_body', models.TextField()),
+				('categories_heading', models.CharField(default='Categories We Cover', max_length=80)),
+				('categories', models.TextField(help_text='Comma-separated list of category labels (e.g. "Culture, Entertainment, Tourism").')),
+				('founder_title', models.CharField(default='Founded by Ephraim Kanyandula', max_length=120)),
+				('founder_body', models.TextField()),
+				('is_published', models.BooleanField(default=True)),
+				('updated_at', models.DateTimeField(auto_now=True)),
+			],
+			options={
+				'verbose_name': 'About page',
+				'verbose_name_plural': 'About page',
+			},
+		),
+		migrations.RunPython(seed_about, unseed_about),
+		migrations.DeleteModel(
+			name='Page',
+		),
+	]

--- a/personal/models.py
+++ b/personal/models.py
@@ -1,6 +1,5 @@
 import uuid
 from django.db import models
-from django_ckeditor_5.fields import CKEditor5Field
 
 
 class Subscriber(models.Model):
@@ -13,21 +12,40 @@ class Subscriber(models.Model):
 		return self.email
 
 
-class Page(models.Model):
-	"""Admin-editable static page (about, privacy, terms, etc.).
+class AboutPage(models.Model):
+	"""Singleton model holding the editable copy for /about.
 
-	Slug is the URL key. The view fetches by slug; the page-chrome wrapper
-	lives in the template so admins can change copy without breaking layout.
+	Structured fields map to fixed visual sections in the template (intro,
+	mission card, categories grid, founder callout). The template owns the
+	chrome — admins edit only the words, so the layout cannot be broken.
 	"""
 
-	slug = models.SlugField(unique=True, max_length=50)
-	title = models.CharField(max_length=120)
-	body = CKEditor5Field(config_name='default')
+	intro = models.TextField(
+		help_text='The opening paragraph beneath the page title.',
+	)
+
+	mission_title = models.CharField(max_length=80, default='Our Mission')
+	mission_body = models.TextField()
+
+	categories_heading = models.CharField(max_length=80, default='Categories We Cover')
+	categories = models.TextField(
+		help_text='Comma-separated list of category labels (e.g. "Culture, Entertainment, Tourism").',
+	)
+
+	founder_title = models.CharField(max_length=120, default='Founded by Ephraim Kanyandula')
+	founder_body = models.TextField()
+
 	is_published = models.BooleanField(default=True)
 	updated_at = models.DateTimeField(auto_now=True)
 
 	class Meta:
-		ordering = ['slug']
+		verbose_name = 'About page'
+		verbose_name_plural = 'About page'
 
 	def __str__(self):
-		return f"{self.slug} — {self.title}"
+		return 'About page content'
+
+	@property
+	def category_list(self):
+		"""Split the comma-separated `categories` field into a clean list."""
+		return [c.strip() for c in self.categories.split(',') if c.strip()]

--- a/personal/templates/personal/about.html
+++ b/personal/templates/personal/about.html
@@ -1,20 +1,38 @@
 {% extends 'base.html' %}
-{% load sanitize %}
 
-{% block title %}{% if page %}{{ page.title }}{% else %}About{% endif %} | NyasaBlog{% endblock %}
+{% block title %}About | NyasaBlog{% endblock %}
 
 {% block content %}
 <div class="max-w-3xl mx-auto px-6 md:px-12">
-  <h1 class="text-3xl md:text-4xl font-black text-primary mb-6">{% if page %}{{ page.title }}{% else %}About NyasaBlog{% endif %}</h1>
+  <h1 class="text-3xl md:text-4xl font-black text-primary mb-6">About NyasaBlog</h1>
 
-  <div class="prose prose-lg max-w-none text-on-surface text-on-surface-variant">
-    {% if page %}
-      {{ page.body|sanitize_html }}
-    {% else %}
-      <p class="text-lg leading-relaxed">
-        NyasaBlog is a digital platform dedicated to promoting positive content created by Malawian content creators and influencers. Our aim is to be the most trusted source for Malawian content in the areas of Culture, Entertainment, Entrepreneurship, and many more.
-      </p>
-    {% endif %}
+  <div class="prose prose-lg max-w-none text-on-surface">
+    <p class="text-lg text-on-surface-variant leading-relaxed">
+      {% if page %}{{ page.intro|linebreaksbr }}{% else %}NyasaBlog is a digital platform dedicated to promoting positive content created by Malawian content creators and influencers. Our aim is to be the most trusted source for Malawian content in the areas of Culture, Entertainment, Entrepreneurship, and many more.{% endif %}
+    </p>
+
+    <div class="bg-surface-container-low p-8 rounded-2xl my-10">
+      <h2 class="text-xl font-bold text-primary mb-3">{% if page %}{{ page.mission_title }}{% else %}Our Mission{% endif %}</h2>
+      <p class="text-on-surface-variant">{% if page %}{{ page.mission_body|linebreaksbr }}{% else %}To amplify Malawian voices and showcase the best of Malawian creativity, innovation, and culture to the world.{% endif %}</p>
+    </div>
+
+    <h2 class="text-xl font-bold text-primary mb-3">{% if page %}{{ page.categories_heading }}{% else %}Categories We Cover{% endif %}</h2>
+    <div class="flex flex-wrap gap-2 mb-8">
+      {% if page %}
+        {% for cat in page.category_list %}
+          <span class="px-4 py-2 rounded-full bg-surface-container text-on-surface-variant text-sm">{{ cat }}</span>
+        {% endfor %}
+      {% else %}
+        <span class="px-4 py-2 rounded-full bg-surface-container text-on-surface-variant text-sm">Culture</span>
+        <span class="px-4 py-2 rounded-full bg-surface-container text-on-surface-variant text-sm">Entertainment</span>
+        <span class="px-4 py-2 rounded-full bg-surface-container text-on-surface-variant text-sm">Entrepreneurship</span>
+      {% endif %}
+    </div>
+
+    <div class="bg-[#0f3d3e] text-white p-8 rounded-2xl">
+      <h2 class="text-xl font-bold mb-3">{% if page %}{{ page.founder_title }}{% else %}Founded by Ephraim Kanyandula{% endif %}</h2>
+      <p class="text-white/80">{% if page %}{{ page.founder_body|linebreaksbr }}{% else %}NyasaBlog was created by Ephraim Kanyandula, a Malawian national, with the vision of building a platform that amplifies Malawian voices and showcases the best of Malawian creativity and innovation.{% endif %}</p>
+    </div>
   </div>
 </div>
 {% endblock content %}

--- a/personal/tests.py
+++ b/personal/tests.py
@@ -1,58 +1,81 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from personal.models import Page
+from personal.models import AboutPage
 
 
 class AboutPageRenderingTests(TestCase):
-	"""The /about view reads from the Page model so admin can edit copy."""
+	"""The /about view reads from the AboutPage singleton so admin can edit copy."""
 
 	def test_about_renders_seeded_page(self):
-		"""Migration 0005 seeds slug='about'; the view must render its title + body."""
+		"""Migration 0006 seeds the singleton; the view must render all sections."""
 		response = self.client.get(reverse('about'))
 		self.assertEqual(response.status_code, 200)
 		self.assertContains(response, 'About NyasaBlog')
 		self.assertContains(response, 'NyasaBlog is a digital platform')
+		self.assertContains(response, 'Our Mission')
+		self.assertContains(response, 'Categories We Cover')
+		self.assertContains(response, 'Founded by Ephraim Kanyandula')
+
+	def test_about_renders_categories_as_chips(self):
+		"""Each comma-separated category should produce its own chip span."""
+		AboutPage.objects.update(categories='Culture, Tourism, Sports')
+		response = self.client.get(reverse('about'))
+		# Each chip is wrapped in a span — search for exact label between tags
+		self.assertContains(response, '>Culture</span>')
+		self.assertContains(response, '>Tourism</span>')
+		self.assertContains(response, '>Sports</span>')
 
 	def test_about_reflects_admin_edits(self):
-		Page.objects.filter(slug='about').update(
-			title='About Us', body='<p>New body content from admin.</p>',
+		AboutPage.objects.update(
+			intro='Brand new intro paragraph.',
+			mission_title='Why we exist',
+			mission_body='Edited mission body.',
+			founder_title='Built by Ephraim',
+			founder_body='Custom founder copy.',
 		)
 		response = self.client.get(reverse('about'))
-		self.assertContains(response, 'About Us')
-		self.assertContains(response, 'New body content from admin.')
+		self.assertContains(response, 'Brand new intro paragraph.')
+		self.assertContains(response, 'Why we exist')
+		self.assertContains(response, 'Edited mission body.')
+		self.assertContains(response, 'Built by Ephraim')
+		self.assertContains(response, 'Custom founder copy.')
 
 	def test_about_falls_back_when_unpublished(self):
-		Page.objects.filter(slug='about').update(is_published=False)
-		response = self.client.get(reverse('about'))
-		self.assertEqual(response.status_code, 200)
-		# Falls back to the static template default heading
-		self.assertContains(response, 'About NyasaBlog')
-
-	def test_about_falls_back_when_page_missing(self):
-		Page.objects.filter(slug='about').delete()
+		AboutPage.objects.update(is_published=False)
 		response = self.client.get(reverse('about'))
 		self.assertEqual(response.status_code, 200)
 		self.assertContains(response, 'About NyasaBlog')
+		# Falls back to the static template default copy
+		self.assertContains(response, 'NyasaBlog is a digital platform')
 
-	def test_page_body_is_sanitized(self):
-		Page.objects.filter(slug='about').update(
-			body='<p>Hello</p><script>alert(99887766)</script><iframe src="evil.example"></iframe>',
-		)
+	def test_about_falls_back_when_singleton_missing(self):
+		AboutPage.objects.all().delete()
 		response = self.client.get(reverse('about'))
-		# Use unique strings so we don't collide with the base template's own scripts.
-		self.assertNotContains(response, 'alert(99887766)')
-		self.assertNotContains(response, 'evil.example')
-		self.assertContains(response, '<p>Hello</p>')
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, 'About NyasaBlog')
+
+	def test_intro_is_html_escaped(self):
+		"""User input through structured fields must be escaped, not rendered as HTML."""
+		AboutPage.objects.update(intro='<script>alert(99887766)</script>')
+		response = self.client.get(reverse('about'))
+		# The raw <script> tag must not appear — Django auto-escape converts it
+		# to &lt;script&gt;, which is harmless text in the rendered page.
+		self.assertNotContains(response, '<script>alert(99887766)')
+		self.assertContains(response, '&lt;script&gt;alert(99887766)')
 
 
-class PageModelTests(TestCase):
-	def test_page_str(self):
-		p = Page.objects.create(slug='terms', title='Terms', body='<p>x</p>')
-		self.assertEqual(str(p), 'terms — Terms')
+class AboutPageModelTests(TestCase):
+	def test_singleton_str(self):
+		page = AboutPage.objects.first()
+		self.assertEqual(str(page), 'About page content')
 
-	def test_slug_unique(self):
-		from django.db import IntegrityError
-		Page.objects.create(slug='privacy', title='Privacy', body='<p>x</p>')
-		with self.assertRaises(IntegrityError):
-			Page.objects.create(slug='privacy', title='Other', body='<p>y</p>')
+	def test_category_list_property_strips_whitespace_and_empties(self):
+		page = AboutPage.objects.first()
+		page.categories = 'Culture,  Tourism ,, Sports ,'
+		self.assertEqual(page.category_list, ['Culture', 'Tourism', 'Sports'])
+
+	def test_category_list_handles_empty_string(self):
+		page = AboutPage.objects.first()
+		page.categories = ''
+		self.assertEqual(page.category_list, [])

--- a/personal/views.py
+++ b/personal/views.py
@@ -128,8 +128,8 @@ def search_view(request):
 
 
 def about_screen_view(request):
-	from personal.models import Page
-	page = Page.objects.filter(slug='about', is_published=True).first()
+	from personal.models import AboutPage
+	page = AboutPage.objects.filter(is_published=True).first()
 	return render(request, 'personal/about.html', {'page': page})
 
 


### PR DESCRIPTION
## Summary

PR #36 wired /about through a free-form CKEditor body. When an admin re-typed the copy, the mission card, category chips, and dark founder callout all disappeared because CKEditor produces only `<p>` and basic inline formatting — no rounded containers, no chip layouts. Result: flat plain-text page.

This PR replaces the generic `Page` model with a singleton **`AboutPage`** that holds one labeled field per visual section. The template owns the chrome; admins type words.

## What changed

- **New `AboutPage` model** (`personal/models.py`) with: `intro`, `mission_title`, `mission_body`, `categories_heading`, `categories` (comma-separated CSV), `founder_title`, `founder_body`, `is_published`, `updated_at`. `category_list` property splits and cleans the CSV.
- **Singleton admin** (`personal/admin.py`) — fieldset-grouped form (Intro / Mission / Categories / Founder). `has_add_permission` blocks creating a second row, `has_delete_permission` is False — admin can only edit the existing row.
- **`about_screen_view`** fetches `AboutPage.objects.filter(is_published=True).first()` with the same template fallback as before.
- **Template** (`personal/templates/personal/about.html`) — restored the original card / chips / callout layout, now driven by structured fields. Categories loop renders one chip per CSV entry.
- **Migration 0006** creates AboutPage, seeds default copy via RunPython, drops the old Page model — single atomic step.
- **9 tests** in `personal/tests.py` covering all sections render, edits propagate, chip count tracks the CSV, fallback paths, and HTML auto-escape on admin input.

## Why a singleton, not a generic Page model

The Page model from PR #36 was sized for content reuse (`/about`, `/privacy`, `/terms` from the same model). In practice each of those pages has very different visual structure — a single rich-text body for any of them produces the same ugly result. If `/privacy` and `/terms` need editable copy later, they get their own structured models (or use `django-flatpages` for plain prose).

## Test plan
- [x] `python manage.py test` — 221/221 pass locally
- [x] Local runserver smoke render — confirmed mission card, 10 chips, dark callout all render
- [ ] On staging/prod after deploy: `/about` renders identical to current production
- [ ] `/admin/personal/aboutpage/` — confirm singleton edit form (no Add button if row exists)
- [ ] Edit `mission_body`, save → reload `/about` and confirm change
- [ ] Edit `categories` to "Foo, Bar, Baz" — confirm exactly 3 chips render

## Deploy steps
1. Merge PR
2. `/nyasablog-deploy` (rsync + chown)
3. SSH: `cd /home/ephraim/djangoprojectdir && sudo -u ephraim djangoprojectenv/bin/python manage.py migrate personal`
4. `systemctl restart gunicorn`

The migration is atomic — Page table drops + AboutPage created + seeded in one operation. Any custom edits made via PR #36's admin will be lost (the seeded defaults restore the original copy).