### PR TITLE
Search: fix M2M tag join across terms + decode HTML entities

### DIFF
--- a/blog/migrations/0013_rebackfill_body_plain_unescape.py
+++ b/blog/migrations/0013_rebackfill_body_plain_unescape.py
@@ -1,0 +1,34 @@
+import html
+
+from django.db import migrations
+from django.utils.html import strip_tags
+
+
+def rebackfill_with_unescape(apps, schema_editor):
+	"""Re-populate body_plain decoding HTML entities (&amp; → &).
+
+	0012 backfilled with strip_tags only, leaving entities literal. This pass
+	matches the new pre_save logic so existing rows stay aligned with future
+	saves.
+	"""
+	BlogPost = apps.get_model('blog', 'BlogPost')
+	for post in BlogPost.objects.all().only('id', 'body'):
+		post.body_plain = ' '.join(html.unescape(strip_tags(post.body or '')).split())
+		post.save(update_fields=['body_plain'])
+
+
+def noop(apps, schema_editor):
+	# Reverse is a no-op — the previous migration's value is still a valid
+	# (just less-decoded) representation of the body.
+	pass
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('blog', '0012_backfill_body_plain'),
+	]
+
+	operations = [
+		migrations.RunPython(rebackfill_with_unescape, noop),
+	]

--- a/blog/models.py
+++ b/blog/models.py
@@ -1,3 +1,6 @@
+import html
+import uuid
+
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import pre_save
@@ -7,7 +10,6 @@ from django.conf import settings
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django_ckeditor_5.fields import CKEditor5Field
-import uuid
 
 
 def upload_location(instance, filename):
@@ -141,6 +143,8 @@ def pre_save_blog_post_receiver(sender, instance, *args, **kwargs):
 			counter += 1
 		instance.slug = slug
 	# Keep the searchable plain-text mirror in sync with the rich body.
-	instance.body_plain = ' '.join(strip_tags(instance.body or '').split())
+	# strip_tags removes <p> etc but leaves entities; html.unescape converts
+	# &amp; → & so a search for "and" doesn't miss bodies that use entities.
+	instance.body_plain = ' '.join(html.unescape(strip_tags(instance.body or '')).split())
 
 pre_save.connect(pre_save_blog_post_receiver, sender=BlogPost)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -546,6 +546,54 @@ class SearchQueryTests(ModelTestMixin, TestCase):
 		results = self._q('tea')
 		self.assertEqual(results.count(self.combined_post), 1)
 
+	def test_AND_across_terms_split_across_separate_tags(self):
+		"""Regression: a post with tags=['malawi-region', 'tea-farming'] and
+		nothing else matching must still match the query 'malawi tea'.
+
+		The previous implementation combined per-term Qs with & and passed
+		one filter() call to the ORM, which collapsed the tag join into a
+		single row — making this case incorrectly miss.
+		"""
+		from blog.models import BlogPost, Tag
+		from account.models import Account
+		# Author username and post title/body deliberately contain neither term.
+		neutral_author = Account.objects.create_user(
+			email='neutral@nyasablog.com', username='neutral', password='x',  # pragma: allowlist secret
+		)
+		split_tag_post = BlogPost.objects.create(
+			title='Highland farming',
+			body='<p>A profile of two regional industries.</p>',
+			author=neutral_author, status='published', category=self.category,
+		)
+		t_malawi, _ = Tag.objects.get_or_create(name='malawi-region', slug='malawi-region')
+		t_tea, _ = Tag.objects.get_or_create(name='tea-farming', slug='tea-farming')
+		split_tag_post.tags.add(t_malawi, t_tea)
+		self.assertIn(split_tag_post, self._q('malawi tea'))
+
+
+class BodyPlainEntityDecodingTests(ModelTestMixin, TestCase):
+	"""body_plain should decode HTML entities so search 'and' matches '&amp;' bodies."""
+
+	def test_entities_are_decoded(self):
+		from blog.models import BlogPost
+		post = BlogPost.objects.create(
+			title='Tea & coffee',
+			body='<p>Tea &amp; coffee &mdash; tradition.</p>',
+			author=self.user, status='published',
+		)
+		self.assertEqual(post.body_plain, 'Tea & coffee — tradition.')
+
+	def test_search_finds_entity_decoded_text(self):
+		from blog.models import BlogPost
+		from blog.views import get_blog_queryset
+		post = BlogPost.objects.create(
+			title='Title without amp', body='<p>Coffee &amp; tea</p>',
+			author=self.user, status='published',
+		)
+		# Searching the literal text 'Coffee & tea' should hit (after decoding)
+		results = list(get_blog_queryset('Coffee tea'))
+		self.assertIn(post, results)
+
 
 class SearchViewIntegrationTests(ModelTestMixin, TestCase):
 	"""End-to-end through the search view: min-length hint, dropdown vs full page."""

--- a/blog/views.py
+++ b/blog/views.py
@@ -107,13 +107,16 @@ def get_blog_queryset(query=None):
 	  * Body matching uses the plain-text mirror `body_plain`, so HTML tag names
 	    (div, class, style) no longer leak as matches.
 	  * Coverage: title, body_plain, author username, category name, tag names.
+
+	Chained .filter() is used (not combined Qs) so each term gets its own
+	join to the tags M2M. With combined Qs Django collapses the join, and
+	'malawi tea' would miss a post whose tags split the terms across rows.
 	"""
 	if not query or len(query.strip()) < SEARCH_MIN_LENGTH:
 		return BlogPost.objects.none()
 
-	terms = query.split()
-	combined = Q()
-	for term in terms:
+	queryset = BlogPost.objects.filter(status='published')
+	for term in query.split():
 		per_term = (
 			Q(title__icontains=term)
 			| Q(body_plain__icontains=term)
@@ -121,11 +124,10 @@ def get_blog_queryset(query=None):
 			| Q(category__name__icontains=term)
 			| Q(tags__name__icontains=term)
 		)
-		combined &= per_term
+		queryset = queryset.filter(per_term)
 
 	return (
-		BlogPost.objects.filter(combined, status='published')
-		.select_related('author', 'category')
+		queryset.select_related('author', 'category')
 		.prefetch_related('tags')
 		.distinct()
 	)


### PR DESCRIPTION
## Summary

Two follow-ups to PR #39, both flagged in self-review before that merge but punted to a dedicated PR.

### 1. M2M tag join collapsed across terms (correctness bug)

PR #39 built the AND-across-terms filter as a single combined `Q`:

```python
combined = Q()
for term in terms:
    per_term = Q(title__icontains=term) | ... | Q(tags__name__icontains=term)
    combined &= per_term
return BlogPost.objects.filter(combined, status='published').distinct()
```

Django collapses joins for a single `.filter()` call, so all per-term `tags__name` conditions evaluate against the **same** tag row. A post with `tags=['malawi-region', 'tea-farming']` and nothing matching in title/body/category/author would NOT match the query `malawi tea` — because no single tag row contained both terms.

This PR chains `.filter(per_term)` in a loop instead. Each call adds its own join, so different terms can match different tag rows.

### 2. HTML entities not decoded in `body_plain`

`strip_tags("Tea &amp; coffee")` returns `"Tea &amp; coffee"` (entity preserved). CKEditor sometimes emits `&amp;` for literal `&`, so a search for `coffee` would still find it but a search for `Tea & coffee` (or even just `&`) would either miss or behave oddly.

`html.unescape(strip_tags(body))` decodes entities before storing in `body_plain`. Migration 0013 re-runs the backfill so the existing 33 posts pick up the new normalization on deploy.

## Tests

Two regression tests in `blog/tests.py`:

- **`test_AND_across_terms_split_across_separate_tags`** — creates a post with two tags, queries terms that only match across both tags, asserts the post is in results. **This test would have failed against PR #39's implementation** — it directly verifies the fix.
- **`test_entities_are_decoded`** + **`test_search_finds_entity_decoded_text`** — confirms `&amp;` becomes `&` in body_plain and that searching the decoded form finds the post.

242/242 project tests pass.

## Deploy

PR #39 is merged but not deployed. This PR can ship together with #39 in one rsync + migrate + restart cycle:

```
rsync ...
ssh ... 'cd /home/ephraim/djangoprojectdir && sudo -u ephraim djangoprojectenv/bin/python manage.py migrate blog'
ssh ... 'systemctl restart gunicorn'
```

Migrations 0011 + 0012 + 0013 all run in sequence. 0012 backfills with the original (no-unescape) logic, then 0013 immediately overwrites with the corrected logic. Sub-second on 33 posts.