### PR TITLE
Nav and CTA animation polish (PR 1 of 2)

### DIFF
--- a/account/templates/account/partials/login_form.html
+++ b/account/templates/account/partials/login_form.html
@@ -35,5 +35,5 @@
     <a href="{% url 'password_reset' %}" class="text-secondary font-medium hover:underline">Forgot password?</a>
   </div>
 
-  <button type="submit" class="w-full bg-primary-container text-on-primary py-3 rounded-lg font-semibold hover:opacity-90 transition-opacity">Sign In</button>
+  <button type="submit" class="w-full bg-primary-container text-on-primary py-3 rounded-lg font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.98]">Sign In</button>
 </form>

--- a/account/templates/account/partials/register_form.html
+++ b/account/templates/account/partials/register_form.html
@@ -24,7 +24,7 @@
   </div>
   {% endfor %}
 
-  <button type="submit" class="w-full bg-primary-container text-on-primary py-3 rounded-lg font-semibold hover:opacity-90 transition-opacity">Create Account</button>
+  <button type="submit" class="w-full bg-primary-container text-on-primary py-3 rounded-lg font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.98]">Create Account</button>
 
   <p class="text-xs text-on-surface-variant text-center">By creating an account, you agree to our Terms and Privacy Policy</p>
 </form>

--- a/blog/templates/blog/detail_blog.html
+++ b/blog/templates/blog/detail_blog.html
@@ -21,8 +21,8 @@
     <div class="w-px h-8 bg-outline-variant/30"></div>
     {% include 'blog/partials/bookmark_button.html' %}
     <div class="w-px h-8 bg-outline-variant/30"></div>
-    <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="p-3 rounded-[10px] text-[#25D366] hover:bg-surface-container-low transition-colors">
-      <span class="material-symbols-outlined">share</span>
+    <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="p-3 rounded-[10px] text-[#25D366] hover:bg-surface-container-low transition motion-safe:active:scale-90">
+      <span class="material-symbols-outlined motion-safe:transition-transform motion-safe:hover:scale-110">share</span>
     </a>
   </aside>
 
@@ -49,8 +49,8 @@
       <div class="flex lg:hidden items-center gap-2 ml-auto">
         {% include 'blog/partials/like_button_mobile.html' %}
         {% include 'blog/partials/bookmark_button_mobile.html' %}
-        <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="p-2 text-[#25D366]">
-          <span class="material-symbols-outlined text-xl">share</span>
+        <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="p-2 text-[#25D366] transition motion-safe:active:scale-90">
+          <span class="material-symbols-outlined text-xl motion-safe:transition-transform motion-safe:hover:scale-110">share</span>
         </a>
       </div>
     </div>
@@ -76,12 +76,12 @@
     <!-- Share Bar -->
     <div class="flex flex-wrap gap-3 mb-12 p-6 bg-surface-container-low rounded-2xl">
       <span class="text-sm font-bold text-on-surface self-center mr-2">Share:</span>
-      <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="bg-[#25D366] text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 flex items-center gap-2">
+      <a href="https://wa.me/?text={{ blog_post.title|urlencode }}%20{{ request.build_absolute_uri }}" target="_blank" class="bg-[#25D366] text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition motion-safe:active:scale-95 flex items-center gap-2">
         <span class="material-symbols-outlined text-base">chat</span> WhatsApp
       </a>
-      <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}" target="_blank" class="bg-[#1877F2] text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90">Facebook</a>
-      <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri }}&text={{ blog_post.title|urlencode }}" target="_blank" class="bg-[#1DA1F2] text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90">Twitter</a>
-      <button onclick="navigator.clipboard.writeText(window.location.href)" class="bg-surface-container-high text-on-surface px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-container-highest transition-colors flex items-center gap-1">
+      <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}" target="_blank" class="bg-[#1877F2] text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition motion-safe:active:scale-95">Facebook</a>
+      <a href="https://twitter.com/intent/tweet?url={{ request.build_absolute_uri }}&text={{ blog_post.title|urlencode }}" target="_blank" class="bg-[#1DA1F2] text-white px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition motion-safe:active:scale-95">Twitter</a>
+      <button onclick="navigator.clipboard.writeText(window.location.href)" class="bg-surface-container-high text-on-surface px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-container-highest transition motion-safe:active:scale-95 flex items-center gap-1">
         <span class="material-symbols-outlined text-base">link</span> Copy Link
       </button>
     </div>
@@ -94,7 +94,7 @@
         {% if blog_post.author.profile.bio %}
         <p class="text-sm text-on-surface-variant mt-2">{{ blog_post.author.profile.bio }}</p>
         {% endif %}
-        <a href="{% url 'author_profile' blog_post.author.username %}" class="inline-block mt-4 bg-primary text-on-primary px-6 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity">View Profile</a>
+        <a href="{% url 'author_profile' blog_post.author.username %}" class="inline-block mt-4 bg-primary text-on-primary px-6 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.97]">View Profile</a>
       </div>
     </div>
 
@@ -109,7 +109,7 @@
             hx-on::after-request="if(event.detail.successful) this.reset()"
             class="mb-8">
         <textarea name="body" rows="3" placeholder="Write a comment..." class="w-full bg-surface-container-lowest border border-outline-variant/20 rounded-xl py-3 px-4 text-sm focus:ring-2 focus:ring-secondary/20 focus:border-secondary resize-none"></textarea>
-        <button type="submit" class="mt-3 bg-primary-container text-on-primary px-6 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity">Post Comment</button>
+        <button type="submit" class="mt-3 bg-primary-container text-on-primary px-6 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.97]">Post Comment</button>
       </form>
       {% else %}
       <p class="text-sm text-on-surface-variant mb-8"><a href="{% url 'login' %}" class="text-secondary font-medium">Sign in</a> to leave a comment.</p>
@@ -151,10 +151,10 @@
   <aside class="hidden lg:block lg:col-span-3">
     <div class="sticky top-28">
       {% if request.user.is_authenticated and blog_post.author == request.user %}
-      <a href="{% url 'blog:edit' blog_post.slug %}" class="block w-full bg-primary-container text-on-primary text-center px-6 py-2.5 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity mb-4">
+      <a href="{% url 'blog:edit' blog_post.slug %}" class="block w-full bg-primary-container text-on-primary text-center px-6 py-2.5 rounded-lg text-sm font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.98] mb-4">
         <span class="material-symbols-outlined text-sm align-middle mr-1">edit</span> Edit Post
       </a>
-      <a href="{% url 'blog:delete' blog_post.pk %}" class="block w-full bg-error-container text-on-error-container text-center px-6 py-2.5 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity mb-6">
+      <a href="{% url 'blog:delete' blog_post.pk %}" class="block w-full bg-error-container text-on-error-container text-center px-6 py-2.5 rounded-lg text-sm font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.98] mb-6">
         <span class="material-symbols-outlined text-sm align-middle mr-1">delete</span> Delete Post
       </a>
       {% endif %}

--- a/blog/templates/blog/partials/bookmark_button.html
+++ b/blog/templates/blog/partials/bookmark_button.html
@@ -3,7 +3,7 @@
      hx-target="this"
      hx-swap="outerHTML">
   <button type="button"
-          class="p-3 rounded-[10px] hover:bg-surface-container-low transition-colors {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
-    <span class="material-symbols-outlined" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
+          class="p-3 rounded-[10px] hover:bg-surface-container-low transition motion-safe:active:scale-90 {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined motion-safe:transition-transform motion-safe:hover:scale-110" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
   </button>
 </div>

--- a/blog/templates/blog/partials/bookmark_button_mobile.html
+++ b/blog/templates/blog/partials/bookmark_button_mobile.html
@@ -3,7 +3,7 @@
      hx-target="this"
      hx-swap="outerHTML">
   <button type="button"
-          class="p-2 {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
-    <span class="material-symbols-outlined text-xl" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
+          class="p-2 transition motion-safe:active:scale-90 {% if is_bookmarked %}text-secondary{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined text-xl motion-safe:transition-transform motion-safe:hover:scale-110" {% if is_bookmarked %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
   </button>
 </div>

--- a/blog/templates/blog/partials/like_button.html
+++ b/blog/templates/blog/partials/like_button.html
@@ -3,8 +3,8 @@
      hx-target="this"
      hx-swap="outerHTML">
   <button type="button"
-          class="p-3 rounded-[10px] hover:bg-surface-container-low transition-colors {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
-    <span class="material-symbols-outlined" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
+          class="p-3 rounded-[10px] hover:bg-surface-container-low transition motion-safe:active:scale-90 {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined motion-safe:transition-transform motion-safe:hover:scale-110" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
   </button>
   <span class="text-xs text-on-surface-variant">{{ like_count }}</span>
 </div>

--- a/blog/templates/blog/partials/like_button_mobile.html
+++ b/blog/templates/blog/partials/like_button_mobile.html
@@ -3,8 +3,8 @@
      hx-target="this"
      hx-swap="outerHTML">
   <button type="button"
-          class="p-2 {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
-    <span class="material-symbols-outlined text-xl" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
+          class="p-2 transition motion-safe:active:scale-90 {% if is_liked %}text-error{% else %}text-on-surface-variant{% endif %}">
+    <span class="material-symbols-outlined text-xl motion-safe:transition-transform motion-safe:hover:scale-110" {% if is_liked %}style="font-variation-settings: 'FILL' 1"{% endif %}>favorite</span>
   </button>
   <span class="text-xs text-on-surface-variant">{{ like_count }}</span>
 </div>

--- a/personal/templates/personal/home.html
+++ b/personal/templates/personal/home.html
@@ -75,7 +75,7 @@
 
       <!-- Create Post CTA -->
       {% if request.user.is_authenticated %}
-      <a href="{% url 'blog:create' %}" class="block bg-[#0f3d3e] text-white p-6 rounded-2xl hover:opacity-90 transition-opacity">
+      <a href="{% url 'blog:create' %}" class="block bg-[#0f3d3e] text-white p-6 rounded-2xl hover:opacity-90 transition motion-safe:active:scale-[0.98]">
         <div class="flex items-center gap-3 mb-3">
           <span class="material-symbols-outlined">edit</span>
           <span class="font-bold text-lg">Write a Story</span>
@@ -108,7 +108,7 @@
         <p class="text-sm text-white/70 mb-4">The best of Malawian stories, every Monday morning.</p>
         <form hx-post="{% url 'subscribe' %}" hx-target="#newsletter-msg-home" hx-swap="innerHTML" hx-on::after-request="if(event.detail.successful) this.reset()">
           <input name="email" class="w-full bg-white/10 border-none rounded-lg py-2.5 px-4 text-sm text-white placeholder:text-white/50 mb-3" placeholder="Your email address" type="email"/>
-          <button type="submit" class="w-full bg-tertiary-fixed-dim text-[#002627] py-2.5 rounded-lg text-sm font-bold hover:opacity-90 transition-opacity">Subscribe</button>
+          <button type="submit" class="w-full bg-tertiary-fixed-dim text-[#002627] py-2.5 rounded-lg text-sm font-bold hover:opacity-90 transition motion-safe:active:scale-[0.97]">Subscribe</button>
         </form>
         <p id="newsletter-msg-home" class="text-xs text-white/70 mt-2 empty:hidden"></p>
       </div>
@@ -121,37 +121,39 @@
 
 <!-- Mobile FAB -->
 {% if request.user.is_authenticated %}
-<a href="{% url 'blog:create' %}" class="fixed bottom-24 right-6 md:hidden w-14 h-14 rounded-full bg-primary text-on-primary flex items-center justify-center shadow-lg hover:opacity-90 transition-opacity z-40">
+<a href="{% url 'blog:create' %}" class="fixed bottom-24 right-6 md:hidden w-14 h-14 rounded-full bg-primary text-on-primary flex items-center justify-center shadow-lg hover:opacity-90 transition motion-safe:active:scale-90 z-40">
   <span class="material-symbols-outlined text-2xl">edit</span>
 </a>
 {% endif %}
 
 <!-- Mobile Bottom Nav -->
+{% with active=request.resolver_match.url_name %}
 <nav class="fixed bottom-0 left-0 w-full md:hidden bg-surface-container-lowest/90 backdrop-blur-md rounded-t-[10px] z-50">
   <div class="flex justify-around py-3">
-    <a href="{% url 'home' %}" class="flex flex-col items-center text-primary">
-      <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1">home</span>
+    <a href="{% url 'home' %}" class="flex flex-col items-center transition motion-safe:active:scale-90 {% if active == 'home' %}text-primary{% else %}text-on-surface-variant{% endif %}">
+      <span class="material-symbols-outlined" {% if active == 'home' %}style="font-variation-settings: 'FILL' 1"{% endif %}>home</span>
       <span class="text-[10px] mt-0.5">Home</span>
     </a>
-    <a href="{% url 'home' %}" class="flex flex-col items-center text-on-surface-variant">
-      <span class="material-symbols-outlined">search</span>
+    <a href="{% url 'search' %}" class="flex flex-col items-center transition motion-safe:active:scale-90 {% if active == 'search' %}text-primary{% else %}text-on-surface-variant{% endif %}">
+      <span class="material-symbols-outlined" {% if active == 'search' %}style="font-variation-settings: 'FILL' 1"{% endif %}>search</span>
       <span class="text-[10px] mt-0.5">Search</span>
     </a>
     {% if request.user.is_authenticated %}
-    <a href="{% url 'blog:bookmarks' %}" class="flex flex-col items-center text-on-surface-variant">
-      <span class="material-symbols-outlined">bookmark</span>
+    <a href="{% url 'blog:bookmarks' %}" class="flex flex-col items-center transition motion-safe:active:scale-90 {% if active == 'bookmarks' %}text-primary{% else %}text-on-surface-variant{% endif %}">
+      <span class="material-symbols-outlined" {% if active == 'bookmarks' %}style="font-variation-settings: 'FILL' 1"{% endif %}>bookmark</span>
       <span class="text-[10px] mt-0.5">Bookmarks</span>
     </a>
-    <a href="{% url 'account' %}" class="flex flex-col items-center text-on-surface-variant">
-      <span class="material-symbols-outlined">person</span>
+    <a href="{% url 'account' %}" class="flex flex-col items-center transition motion-safe:active:scale-90 {% if active == 'account' %}text-primary{% else %}text-on-surface-variant{% endif %}">
+      <span class="material-symbols-outlined" {% if active == 'account' %}style="font-variation-settings: 'FILL' 1"{% endif %}>person</span>
       <span class="text-[10px] mt-0.5">Profile</span>
     </a>
     {% else %}
-    <a href="{% url 'login' %}" class="flex flex-col items-center text-on-surface-variant">
-      <span class="material-symbols-outlined">login</span>
+    <a href="{% url 'login' %}" class="flex flex-col items-center transition motion-safe:active:scale-90 {% if active == 'login' %}text-primary{% else %}text-on-surface-variant{% endif %}">
+      <span class="material-symbols-outlined" {% if active == 'login' %}style="font-variation-settings: 'FILL' 1"{% endif %}>login</span>
       <span class="text-[10px] mt-0.5">Sign in</span>
     </a>
     {% endif %}
   </div>
 </nav>
+{% endwith %}
 {% endblock content %}

--- a/personal/templates/personal/partials/home_content.html
+++ b/personal/templates/personal/partials/home_content.html
@@ -3,7 +3,7 @@
   <a href="{% url 'home' %}"
      hx-get="{% url 'home' %}?partial=home_content"
      hx-target="#home-content"
-     hx-swap="innerHTML"
+     hx-swap="innerHTML swap:150ms"
      hx-push-url="{% url 'home' %}"
      class="px-5 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors {% if not active_category %}bg-primary text-on-primary{% else %}bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest{% endif %}">
     All
@@ -12,7 +12,7 @@
   <a href="{% url 'home' %}?category={{ cat.slug }}"
      hx-get="{% url 'home' %}?category={{ cat.slug }}&partial=home_content"
      hx-target="#home-content"
-     hx-swap="innerHTML"
+     hx-swap="innerHTML swap:150ms"
      hx-push-url="{% url 'home' %}?category={{ cat.slug }}"
      class="px-5 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors {% if active_category == cat.slug %}bg-primary text-on-primary{% else %}bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest{% endif %}">
     {{ cat.name }}
@@ -30,6 +30,6 @@
   <span class="material-symbols-outlined text-6xl text-outline-variant mb-4">search_off</span>
   <h3 class="text-xl font-bold text-primary mb-2">No stories found</h3>
   <p class="text-on-surface-variant mb-6">Try different keywords or browse categories</p>
-  <a href="{% url 'home' %}" class="bg-primary-container text-on-primary px-6 py-2.5 rounded-lg font-semibold hover:opacity-90 transition-opacity">Browse All</a>
+  <a href="{% url 'home' %}" class="bg-primary-container text-on-primary px-6 py-2.5 rounded-lg font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.97] inline-block">Browse All</a>
 </div>
 {% endif %}

--- a/templates/snippets/base_css.html
+++ b/templates/snippets/base_css.html
@@ -95,4 +95,19 @@
         to { transform: translateX(0); opacity: 1; }
     }
     .animate-slide-in { animation: slide-in-right 0.3s ease-out; }
+
+    /* HTMX swap fade — opt-in via swap:Xms modifier on hx-swap */
+    @media (prefers-reduced-motion: no-preference) {
+        .htmx-swapping {
+            opacity: 0;
+            transition: opacity 150ms ease-out;
+        }
+        .htmx-added {
+            animation: htmx-fade-in 200ms ease-in;
+        }
+        @keyframes htmx-fade-in {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+    }
 </style>

--- a/templates/snippets/header.html
+++ b/templates/snippets/header.html
@@ -3,8 +3,8 @@
 <header class="fixed top-0 w-full z-50 bg-background/85 backdrop-blur-xl">
 <nav class="flex justify-between items-center px-6 md:px-12 h-16 md:h-20 max-w-[1440px] mx-auto">
   <!-- Mobile menu button -->
-  <button class="md:hidden p-2 text-on-surface" id="mobile-menu-btn">
-    <span class="material-symbols-outlined text-2xl">menu</span>
+  <button class="md:hidden p-2 text-on-surface transition motion-safe:active:scale-90" id="mobile-menu-btn" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+    <span class="material-symbols-outlined text-2xl" id="mobile-menu-icon">menu</span>
   </button>
 
   <!-- Logo -->
@@ -30,7 +30,7 @@
              hx-get="{% url 'search' %}"
              hx-trigger="input changed delay:300ms, search"
              hx-target="#search-dropdown"
-             hx-swap="innerHTML"
+             hx-swap="innerHTML swap:150ms"
              hx-vals='{"partial": "search_dropdown"}'
              hx-sync="this:replace"
              autocomplete="off"
@@ -47,23 +47,23 @@
     </form>
 
     <!-- Mobile search button -->
-    <a href="{% url 'search' %}" class="lg:hidden p-2">
+    <a href="{% url 'search' %}" class="lg:hidden p-2 transition motion-safe:active:scale-90">
       <span class="material-symbols-outlined text-on-surface">search</span>
     </a>
 
     <!-- Dark mode toggle -->
-    <button onclick="toggleTheme()" class="p-2 text-on-surface-variant hover:text-primary transition-colors" title="Toggle dark mode">
-      <span class="material-symbols-outlined" id="theme-icon">dark_mode</span>
+    <button onclick="toggleTheme()" class="p-2 text-on-surface-variant hover:text-primary transition motion-safe:active:scale-90" title="Toggle dark mode">
+      <span class="material-symbols-outlined motion-safe:transition-transform motion-safe:hover:rotate-12" id="theme-icon">dark_mode</span>
     </button>
 
     {% if request.user.is_authenticated %}
       <!-- Bookmarks -->
-      <a href="{% url 'blog:bookmarks' %}" class="hidden md:block p-2" title="Bookmarks">
-        <span class="material-symbols-outlined text-on-surface">bookmark</span>
+      <a href="{% url 'blog:bookmarks' %}" class="hidden md:block p-2 transition motion-safe:active:scale-90" title="Bookmarks">
+        <span class="material-symbols-outlined text-on-surface motion-safe:transition-transform motion-safe:hover:scale-110">bookmark</span>
       </a>
       <!-- Account dropdown -->
       <div class="relative">
-        <button id="account-menu-btn" class="flex items-center gap-2 cursor-pointer active:scale-95 transition-transform">
+        <button id="account-menu-btn" class="flex items-center gap-2 cursor-pointer transition motion-safe:active:scale-95">
           <span class="material-symbols-outlined text-3xl text-primary">account_circle</span>
           <span class="hidden md:inline text-sm font-medium text-on-surface">{{ request.user.username }}</span>
           <span class="material-symbols-outlined text-sm text-on-surface-variant hidden md:inline">expand_more</span>
@@ -82,8 +82,8 @@
         </div>
       </div>
     {% else %}
-      <a href="{% url 'login' %}" class="hidden md:inline text-sm font-medium text-on-surface hover:text-primary-container transition-colors">Sign in</a>
-      <a href="{% url 'register' %}" class="hidden md:inline bg-primary-container text-on-primary px-4 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity">
+      <a href="{% url 'login' %}" class="hidden md:inline text-sm font-medium text-on-surface hover:text-primary-container transition motion-safe:active:scale-95">Sign in</a>
+      <a href="{% url 'register' %}" class="hidden md:inline bg-primary-container text-on-primary px-4 py-2 rounded-lg text-sm font-semibold hover:opacity-90 transition motion-safe:active:scale-[0.97]">
         Register
       </a>
     {% endif %}
@@ -91,35 +91,59 @@
 </nav>
 
 <!-- Mobile menu overlay -->
-<div class="hidden md:hidden bg-surface-container-lowest border-t border-outline-variant/10 px-6 py-4" id="mobile-menu">
-  <div class="flex flex-col gap-3">
-    <a href="{% url 'home' %}" class="text-on-surface font-medium py-2">Home</a>
-    <a href="{% url 'about' %}" class="text-on-surface/70 py-2">About</a>
-    <a href="{% url 'contact' %}" class="text-on-surface/70 py-2">Contact</a>
-    {% if request.user.is_authenticated %}
-      <a href="{% url 'account' %}" class="text-on-surface/70 py-2">Account</a>
-      <a href="{% url 'logout' %}" class="text-on-surface/70 py-2">Logout</a>
-    {% else %}
-      <a href="{% url 'login' %}" class="text-on-surface/70 py-2">Sign in</a>
-      <a href="{% url 'register' %}" class="bg-[#0f3d3e] text-white text-center py-3 rounded-lg font-semibold mt-2">Register</a>
-    {% endif %}
-  </div>
-  <!-- Mobile search -->
-  <form class="mt-4" action="{% url 'search' %}" method="GET">
-    <div class="relative">
-      <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-outline-variant">search</span>
-      <input class="w-full bg-surface-container-low border-none rounded-full py-2 pl-10 pr-4 text-sm focus:ring-2 focus:ring-secondary/20"
-             placeholder="Search stories..." type="text" name="q" value="{{ query|default:'' }}"/>
+<div id="mobile-menu"
+     class="md:hidden bg-surface-container-lowest border-t border-outline-variant/10 overflow-hidden max-h-0 opacity-0 motion-safe:transition-[max-height,opacity] motion-safe:duration-300 motion-safe:ease-in-out">
+  <div class="px-6 py-4">
+    <div class="flex flex-col gap-3">
+      <a href="{% url 'home' %}" class="text-on-surface font-medium py-2">Home</a>
+      <a href="{% url 'about' %}" class="text-on-surface/70 py-2">About</a>
+      <a href="{% url 'contact' %}" class="text-on-surface/70 py-2">Contact</a>
+      {% if request.user.is_authenticated %}
+        <a href="{% url 'account' %}" class="text-on-surface/70 py-2">Account</a>
+        <a href="{% url 'logout' %}" class="text-on-surface/70 py-2">Logout</a>
+      {% else %}
+        <a href="{% url 'login' %}" class="text-on-surface/70 py-2">Sign in</a>
+        <a href="{% url 'register' %}" class="bg-[#0f3d3e] text-white text-center py-3 rounded-lg font-semibold mt-2 transition motion-safe:active:scale-[0.97]">Register</a>
+      {% endif %}
     </div>
-  </form>
+    <!-- Mobile search -->
+    <form class="mt-4" action="{% url 'search' %}" method="GET">
+      <div class="relative">
+        <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-outline-variant">search</span>
+        <input class="w-full bg-surface-container-low border-none rounded-full py-2 pl-10 pr-4 text-sm focus:ring-2 focus:ring-secondary/20"
+               placeholder="Search stories..." type="text" name="q" value="{{ query|default:'' }}"/>
+      </div>
+    </form>
+  </div>
 </div>
 </header>
 
 <!-- Menu toggle scripts -->
 <script>
-document.getElementById('mobile-menu-btn').addEventListener('click', function() {
-  document.getElementById('mobile-menu').classList.toggle('hidden');
-});
+var mobileMenuBtn = document.getElementById('mobile-menu-btn');
+var mobileMenu = document.getElementById('mobile-menu');
+var mobileMenuIcon = document.getElementById('mobile-menu-icon');
+if (mobileMenuBtn && mobileMenu && mobileMenuIcon) {
+  function setMobileMenuOpen(isOpen) {
+    mobileMenu.classList.toggle('max-h-96', isOpen);
+    mobileMenu.classList.toggle('opacity-100', isOpen);
+    mobileMenu.classList.toggle('max-h-0', !isOpen);
+    mobileMenu.classList.toggle('opacity-0', !isOpen);
+    mobileMenuIcon.textContent = isOpen ? 'close' : 'menu';
+    mobileMenuBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    mobileMenuBtn.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
+  }
+  mobileMenuBtn.addEventListener('click', function() {
+    setMobileMenuOpen(!mobileMenu.classList.contains('max-h-96'));
+  });
+  // Reset state when crossing into desktop breakpoint
+  var mq = window.matchMedia('(min-width: 768px)');
+  function onBreakpointChange(e) {
+    if (e.matches) setMobileMenuOpen(false);
+  }
+  if (mq.addEventListener) mq.addEventListener('change', onBreakpointChange);
+  else mq.addListener(onBreakpointChange);
+}
 
 // Search dropdown: keyboard nav, skeleton loading, aria sync, outside-click close
 var searchInput = document.getElementById('search-input');


### PR DESCRIPTION
## Summary

PR 1 of 2 from the navigation/interaction animation audit. Adds tactile feedback to CTAs, animates the mobile menu, fades HTMX swaps, and gives the mobile bottom nav a real per-tab active state. All transforms gated by `motion-safe:` so `prefers-reduced-motion` users get a snap, not a transform.

PR 2 (separate) will cover `hx-boost` on `<body>` and the View Transitions API for top-level page navigation.

## Changes

### Tactile CTA feedback (`#1`)

`active:scale-{0.9–0.98}` + `transition` (replacing per-prop `transition-opacity`/`transition-colors`) on every CTA. Like and Bookmark also get `hover:scale-110` on the icon glyph; theme toggle gets `hover:rotate-12`.

CTAs touched: Like / Bookmark (desktop + mobile), Theme toggle, Mobile menu button, Header bookmarks shortcut, Mobile search button, Sign in / Register / Sign In submit / Create Account submit, Subscribe, Write a Story sidebar CTA, Mobile FAB, Browse-All empty-state CTA, Post Comment, View Profile, Edit Post, Delete Post, share-bar buttons (WhatsApp / Facebook / Twitter / Copy Link), share icon (desktop + mobile).

### Mobile menu slide animation (`#2`)

Replaced the binary `hidden` toggle:
- Wrapper now transitions `max-h-0 → max-h-96` and `opacity-0 → opacity-100` over 300ms (motion-safe-gated).
- Hamburger icon swaps to `close` when open.
- `aria-expanded`, `aria-label` (`Open menu` / `Close menu`), and `aria-controls` all wired on the button.
- `matchMedia('(min-width: 768px)')` listener resets state when the viewport crosses into desktop, so the icon and aria can't desync at 768px+.

### HTMX swap fade (`#3`)

Opt-in fade for category filter pills and the search dropdown:
- `swap:150ms` modifier added to the relevant `hx-swap` attrs so the `htmx-swapping` and `htmx-added` classes have time to animate.
- New CSS in `templates/snippets/base_css.html` (inside `@media (prefers-reduced-motion: no-preference)`) fades old content out (150ms) and new content in (200ms).

### Mobile bottom-nav active state (`#4`)

`{% with active=request.resolver_match.url_name %}` wraps the nav; each tab gets `text-primary` + filled material symbol when its `url_name` matches. Removed the hardcoded "Home is always active". Also fixed the search-tab URL from `{% url 'home' %}` to `{% url 'search' %}` so the active state can actually trigger when on the search page.

(The mobile bottom nav is currently inside `home.html` so it only renders on `/`; non-home tabs' active states won't trigger until the nav is hoisted to a base template — forward-compatible.)

## Test plan

- [ ] Hover and click each CTA listed above — opacity/color tweens, click depresses with a brief scale.
- [ ] Like and Bookmark icons grow on hover; the button itself depresses on click.
- [ ] Theme toggle: icon rotates 12° on hover, button depresses on click.
- [ ] Open mobile menu — slides down with fade; hamburger flips to `close`. Tap again — slides up.
- [ ] Open the menu, resize past 768px — menu state resets cleanly; tap-back-and-forth works on resize back.
- [ ] Toggle a category filter pill on the home page — old grid fades out, new grid fades in.
- [ ] Type in the desktop search — skeleton appears instantly, then fades to results.
- [ ] Mobile bottom nav: home tab is highlighted with filled icon; other tabs grey.
- [ ] OS reduced-motion enabled (System Settings → Accessibility → Display → Reduce motion) — no scale/rotate on click; menu opens without slide; HTMX swaps without fade.
- [ ] Screen reader announces mobile menu button as "expanded" / "collapsed".

## Files

`account/templates/account/partials/{login_form,register_form}.html`, `blog/templates/blog/detail_blog.html`, `blog/templates/blog/partials/{like,bookmark}_button{,_mobile}.html`, `personal/templates/personal/home.html`, `personal/templates/personal/partials/home_content.html`, `templates/snippets/{base_css,header}.html`.