### PR TITLE
Use primary-container token instead of hardcoded hex on About card

### DIFF
--- a/personal/templates/personal/about.html
+++ b/personal/templates/personal/about.html
@@ -29,7 +29,7 @@
       {% endif %}
     </div>
 
-    <div class="bg-[#0f3d3e] text-white p-8 rounded-2xl">
+    <div class="bg-primary-container text-white p-8 rounded-2xl">
       <h2 class="text-xl font-bold mb-3">{% if page %}{{ page.founder_title }}{% else %}Founded by Ephraim Kanyandula{% endif %}</h2>
       <p class="text-white/80">{% if page %}{{ page.founder_body|linebreaksbr }}{% else %}NyasaBlog was created by Ephraim Kanyandula, a Malawian national, with the vision of building a platform that amplifies Malawian voices and showcases the best of Malawian creativity and innovation.{% endif %}</p>
     </div>


### PR DESCRIPTION
## Summary
- Replace `bg-[#0f3d3e]` on the About-page founder card with the
  `bg-primary-container` semantic token.
- Removes a hardcoded-hex convention violation (CLAUDE.md: dark mode via
  CSS custom properties, no hardcoded colors).

## Visual impact
- **Light mode:** pixel-identical — `--color-primary-container` light is
  exactly `#0f3d3e`.
- **Dark mode:** card now resolves to `#1a4f50` and adapts with the
  palette instead of staying a fixed light-mode teal slab. White body
  text (`text-white` / `text-white/80`) stays ≈8.7:1 on it (AAA).
- Template-only change; compiled CSS already contained
  `.bg-primary-container`, so no asset rebuild.

## Coordination note
Related open PR `fix/about-founder-title-contrast` edits the adjacent
line (the card's `<h2>`). Diff contexts overlap, so depending on merge
order a trivial conflict may surface — resolution is simply keeping both
one-line changes (line 32 token swap + line 33 `text-white`).

## Test plan
- [ ] Load `/about` in light mode — founder card unchanged.
- [ ] Toggle dark mode — card background adapts (teal `#1a4f50`), title
      and body remain readable.