### PR TITLE
Fix unreadable founder-card title on About page

### DIFF
--- a/personal/templates/personal/about.html
+++ b/personal/templates/personal/about.html
@@ -30,7 +30,7 @@
     </div>
 
     <div class="bg-[#0f3d3e] text-white p-8 rounded-2xl">
-      <h2 class="text-xl font-bold mb-3">{% if page %}{{ page.founder_title }}{% else %}Founded by Ephraim Kanyandula{% endif %}</h2>
+      <h2 class="text-xl font-bold mb-3 text-white">{% if page %}{{ page.founder_title }}{% else %}Founded by Ephraim Kanyandula{% endif %}</h2>
       <p class="text-white/80">{% if page %}{{ page.founder_body|linebreaksbr }}{% else %}NyasaBlog was created by Ephraim Kanyandula, a Malawian national, with the vision of building a platform that amplifies Malawian voices and showcases the best of Malawian creativity and innovation.{% endif %}</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add `text-white` to the About-page founder card `<h2>`.
- The card sets a dark background + `text-white`, but the heading had no
  color class, so the `prose` heading rule
  (`--tw-prose-headings: var(--color-on-surface)`) won and rendered the
  title near-black on the dark card — ≈1.5:1, failing WCAG AA.
- Matches the paragraph's existing `text-white/80`; one class, overrides
  the prose rule by source order.

## Deploy status
⚠️ **Already live in production** (hotfix-deployed from this branch on
2026-05-16). This PR exists to bring `master` back in sync with what is
deployed — master is currently *behind* prod by this commit.

## Merge ordering
**Merge this PR FIRST**, then #57. Both edit adjacent lines of
`personal/templates/personal/about.html` (line 33 here, line 32 in #57),
so whichever merges second may hit a trivial conflict — resolution is to
keep **both** one-line changes (the `text-white` on the h2 *and* the
`bg-primary-container` token swap).

## Test plan
- [ ] `/about` (no trailing slash) — founder title legible in light mode.
- [ ] Toggle dark mode — title and body both readable.